### PR TITLE
feat: editorial-light design system + Jellyfin auto-discovery + onboarding wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ data/
 .vscode/
 *.swp
 
+# Superpowers brainstorm scratch (mockups, session state)
+.superpowers/
+
 # Env files
 .env
 .env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ WORKDIR /app
 # Create application directory structure
 RUN mkdir -p \
         /app/data \
+        /app/data/cache/posters \
         /app/config \
         /app/logs \
         /app/public \

--- a/Sources/NocturneServer/APIRoutes.swift
+++ b/Sources/NocturneServer/APIRoutes.swift
@@ -12,6 +12,7 @@ final class APIRoutes: @unchecked Sendable {
   let config: NocturneConfiguration
   let logger = Logger(label: "APIRoutes")
   let httpClient: HTTPClient
+  let posterCache: PosterCache?
 
   init(
     movieService: MovieService,
@@ -23,6 +24,13 @@ final class APIRoutes: @unchecked Sendable {
     self.suggestionService = suggestionService
     self.config = config
     self.httpClient = httpClient
+    self.posterCache = (try? PosterCache(
+      dir: config.posterCacheDir,
+      maxBytes: config.posterCacheMaxBytes
+    ))
+    if self.posterCache == nil {
+      logger.warning("PosterCache init failed; poster endpoint will proxy without caching")
+    }
   }
 
   func addRoutes(to router: Router<BasicRequestContext>) {
@@ -44,6 +52,8 @@ final class APIRoutes: @unchecked Sendable {
     addImportExportRoutes(to: api)
     addClientRoutes(to: api)
     addAdminRoutes(to: api)
+    addJellyfinDiscoveryRoutes(to: api)
+    addOnboardingRoutes(to: api)
   }
 
   // MARK: - Mood Routes (admin needs the bucket list for display names)
@@ -85,6 +95,52 @@ final class APIRoutes: @unchecked Sendable {
       let sugg = try await self.suggestionService.enqueue(jellyfinId: String(jellyfinId))
       return try jsonResponse(TagSuggestionResponse(sugg))
     }
+
+    // Poster proxy: fetches from Jellyfin on cache miss, serves from disk on hit.
+    // Sizes: thumb=200w, medium=400w, full=original.
+    movies.get(":id/poster") { request, context -> Response in
+      let jellyfinId = String(try context.parameters.require("id"))
+      let size = request.uri.queryParameters["size"].map { String($0) } ?? "medium"
+      let fillWidth: Int?
+      switch size {
+      case "thumb":  fillWidth = 200
+      case "full":   fillWidth = nil
+      default:       fillWidth = 400  // "medium" and unknown
+      }
+      let cacheKey = "\(jellyfinId)-\(size)"
+
+      // Cache hit
+      if let entry = self.posterCache?.get(key: cacheKey) {
+        return Self.imageResponse(
+          data: entry.data,
+          contentType: entry.contentType,
+          cacheHit: true
+        )
+      }
+
+      // Miss — fetch from Jellyfin
+      let (data, contentType): (Data, String)
+      do {
+        (data, contentType) = try await self.movieService.jellyfinService
+          .fetchPosterBytes(itemId: jellyfinId, fillWidth: fillWidth)
+      } catch {
+        self.logger.info("Poster fetch failed for \(jellyfinId) size=\(size): \(error)")
+        throw HTTPError(.notFound)
+      }
+
+      self.posterCache?.set(key: cacheKey, data: data, contentType: contentType)
+      return Self.imageResponse(data: data, contentType: contentType, cacheHit: false)
+    }
+  }
+
+  private static func imageResponse(data: Data, contentType: String, cacheHit: Bool) -> Response {
+    let body = responseBody(from: data)
+    let headers = HTTPFields([
+      HTTPField(name: .contentType, value: contentType),
+      HTTPField(name: .cacheControl, value: "public, max-age=604800, immutable"),
+      HTTPField(name: HTTPField.Name("X-Nocturne-Cache")!, value: cacheHit ? "hit" : "miss"),
+    ])
+    return Response(status: .ok, headers: headers, body: body)
   }
 
   // MARK: - Sync Routes
@@ -111,6 +167,24 @@ final class APIRoutes: @unchecked Sendable {
 
     sync.post("test-connection") { request, context in
       return try jsonResponse(try await self.movieService.testJellyfinConnection())
+    }
+  }
+
+  // MARK: - Jellyfin Discovery (UDP broadcast on :7359)
+
+  private func addJellyfinDiscoveryRoutes(to router: RouterGroup<BasicRequestContext>) {
+    let jellyfin = router.group("jellyfin")
+    struct DiscoveryResponse: Codable { let servers: [JellyfinDiscovery.Server] }
+
+    jellyfin.post("discover") { request, context in
+      let timeout = self.config.jellyfinDiscoveryTimeoutMs
+      do {
+        let servers = try await JellyfinDiscovery.discover(timeoutMs: timeout)
+        return try jsonResponse(DiscoveryResponse(servers: servers))
+      } catch {
+        self.logger.warning("Jellyfin discovery failed: \(error)")
+        return try jsonResponse(DiscoveryResponse(servers: []))
+      }
     }
   }
 
@@ -506,6 +580,7 @@ final class APIRoutes: @unchecked Sendable {
       let jellyfin_url: String
       let jellyfin_api_key_set: Bool
       let jellyfin_user_id: String
+      let jellyfin_username: String
       let anthropic_key_set: Bool
       let omdb_key_set: Bool
       let enable_auto_tagging: Bool
@@ -516,12 +591,14 @@ final class APIRoutes: @unchecked Sendable {
       let url = try await store.get("jellyfin_url") ?? self.config.jellyfinUrl
       let uid = try await store.get("jellyfin_user_id") ?? self.config.jellyfinUserId
       let api = (try await store.get("jellyfin_api_key")) ?? self.config.jellyfinApiKey
+      let user = (try await store.get("jellyfin_username")) ?? ""
       let anth = (try await store.get("anthropic_api_key")) ?? (self.config.anthropicApiKey ?? "")
       let omdb = (try await store.get("omdb_api_key")) ?? (self.config.omdbApiKey ?? "")
       let info = SettingsInfo(
         jellyfin_url: url,
         jellyfin_api_key_set: !api.isEmpty,
         jellyfin_user_id: uid,
+        jellyfin_username: user,
         anthropic_key_set: !anth.isEmpty,
         omdb_key_set: !omdb.isEmpty,
         enable_auto_tagging: self.config.enableAutoTagging
@@ -529,6 +606,34 @@ final class APIRoutes: @unchecked Sendable {
       return try jsonResponse(info)
     }
 
+  }
+
+  // MARK: - Onboarding status (first-run detection)
+
+  private func addOnboardingRoutes(to router: RouterGroup<BasicRequestContext>) {
+    let onboarding = router.group("onboarding")
+    struct OnboardingStatusResponse: Codable {
+      let configured: Bool
+      let has_jellyfin: Bool
+      let has_anthropic_key: Bool
+      let has_omdb_key: Bool
+    }
+    onboarding.get("status") { request, context in
+      let store = SettingsStore(db: self.movieService.fluent.db(), logger: self.logger)
+      try await store.ensureTable()
+      let url = (try await store.get("jellyfin_url")) ?? self.config.jellyfinUrl
+      let api = (try await store.get("jellyfin_api_key")) ?? self.config.jellyfinApiKey
+      let uid = (try await store.get("jellyfin_user_id")) ?? self.config.jellyfinUserId
+      let anth = (try await store.get("anthropic_api_key")) ?? (self.config.anthropicApiKey ?? "")
+      let omdb = (try await store.get("omdb_api_key")) ?? (self.config.omdbApiKey ?? "")
+      let hasJellyfin = !url.isEmpty && !api.isEmpty && !uid.isEmpty
+      return try jsonResponse(OnboardingStatusResponse(
+        configured: hasJellyfin,
+        has_jellyfin: hasJellyfin,
+        has_anthropic_key: !anth.isEmpty,
+        has_omdb_key: !omdb.isEmpty
+      ))
+    }
   }
 }
 

--- a/Sources/NocturneServer/Configuration.swift
+++ b/Sources/NocturneServer/Configuration.swift
@@ -18,6 +18,13 @@ final class NocturneConfiguration: @unchecked Sendable {
     var anthropicApiKey: String? = nil
     var omdbApiKey: String? = nil
 
+    // Poster cache (on-disk LRU, proxies Jellyfin images)
+    var posterCacheDir: String = "/app/data/cache/posters"
+    var posterCacheMaxBytes: Int64 = 1_073_741_824  // 1 GiB
+
+    // Jellyfin auto-discovery (UDP broadcast on :7359)
+    var jellyfinDiscoveryTimeoutMs: Int = 2000
+
     // Auto-tagging settings
     var enableAutoTagging: Bool = false
     var maxAutoTags: Int = 5
@@ -865,6 +872,16 @@ You leave having experienced FORM directly — structure, sound, or image pushed
             self.databasePath = path
         } else {
             self.databasePath = "/app/data/nocturne.sqlite"
+        }
+        // Poster cache lives alongside the database so they share volume lifecycle.
+        let dbDir = (self.databasePath as NSString).deletingLastPathComponent
+        self.posterCacheDir = (dbDir as NSString).appendingPathComponent("cache/posters")
+        if let override = ProcessInfo.processInfo.environment["NOCTURNE_POSTER_CACHE_DIR"], !override.isEmpty {
+            self.posterCacheDir = override
+        }
+        if let raw = ProcessInfo.processInfo.environment["NOCTURNE_POSTER_CACHE_MAX_BYTES"],
+           let bytes = Int64(raw), bytes > 0 {
+            self.posterCacheMaxBytes = bytes
         }
     }
 }

--- a/Sources/NocturneServer/JellyfinDiscovery.swift
+++ b/Sources/NocturneServer/JellyfinDiscovery.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Logging
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Jellyfin server auto-discovery using the standard client-discovery protocol.
+///
+/// Sends a UDP broadcast (`"Who is JellyfinServer?"`) to `255.255.255.255:7359`
+/// and collects JSON replies for a short window. This matches the protocol used
+/// by the official Jellyfin mobile/web clients and is supported by every
+/// reasonably recent Jellyfin server (>= 10.x) without any extra configuration.
+///
+/// Deliberately POSIX-sockets-based so it works on macOS and Linux (the Pi
+/// target) without bringing in SwiftNIO or the Apple-only Network framework.
+enum JellyfinDiscovery {
+
+    struct Server: Codable, Sendable {
+        let id: String
+        let name: String
+        let address: String
+        let version: String?
+    }
+
+    /// Jellyfin's on-wire response shape (PascalCase field names).
+    private struct JellyfinResponse: Codable {
+        let address: String?
+        let id: String?
+        let name: String?
+        let endpointAddress: String?
+
+        enum CodingKeys: String, CodingKey {
+            case address = "Address"
+            case id = "Id"
+            case name = "Name"
+            case endpointAddress = "EndpointAddress"
+        }
+    }
+
+    /// Broadcast and collect responses. Returns deduped servers by ID.
+    /// - Parameter timeoutMs: how long to listen after the broadcast.
+    static func discover(timeoutMs: Int = 2000) async throws -> [Server] {
+        let logger = Logger(label: "JellyfinDiscovery")
+
+        // Run the blocking socket work on a background task so we don't stall
+        // the Hummingbird event loop.
+        return try await Task.detached(priority: .userInitiated) {
+            try performDiscovery(timeoutMs: timeoutMs, logger: logger)
+        }.value
+    }
+
+    private static func performDiscovery(timeoutMs: Int, logger: Logger) throws -> [Server] {
+        let fd = socket(AF_INET, SOCK_DGRAM, 0)
+        guard fd >= 0 else {
+            throw DiscoveryError.socketFailed(errno)
+        }
+        defer { close(fd) }
+
+        // Enable broadcast.
+        var yes: Int32 = 1
+        if setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &yes, socklen_t(MemoryLayout<Int32>.size)) < 0 {
+            throw DiscoveryError.setsockoptFailed(errno)
+        }
+
+        // Bind to an ephemeral local port (needed so recvfrom sees replies).
+        var local = sockaddr_in()
+        local.sin_family = sa_family_t(AF_INET)
+        local.sin_port = 0
+        local.sin_addr.s_addr = inaddr_any()
+        #if canImport(Darwin)
+        local.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        #endif
+        let bindResult = withUnsafePointer(to: &local) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        if bindResult < 0 {
+            throw DiscoveryError.bindFailed(errno)
+        }
+
+        // Build the destination (255.255.255.255:7359).
+        var dst = sockaddr_in()
+        dst.sin_family = sa_family_t(AF_INET)
+        dst.sin_port = in_port_t(7359).bigEndian
+        dst.sin_addr.s_addr = 0xFFFFFFFF // INADDR_BROADCAST
+        #if canImport(Darwin)
+        dst.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        #endif
+
+        let message = "Who is JellyfinServer?"
+        let messageBytes = Array(message.utf8)
+        let sent = messageBytes.withUnsafeBufferPointer { buf -> ssize_t in
+            withUnsafePointer(to: &dst) { dstPtr in
+                dstPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                    sendto(fd, buf.baseAddress, buf.count, 0, sockPtr,
+                           socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+        }
+        if sent < 0 {
+            throw DiscoveryError.sendFailed(errno)
+        }
+
+        // Listen for replies up to `timeoutMs`.
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
+        var servers: [String: Server] = [:]
+        var buffer = [UInt8](repeating: 0, count: 4096)
+
+        while Date() < deadline {
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            var tv = timeval(
+                tv_sec: Int(remaining),
+                tv_usec: Int32((remaining - Double(Int(remaining))) * 1_000_000)
+            )
+            var readSet = fd_set()
+            fdZero(&readSet)
+            fdSet(fd, set: &readSet)
+            let ready = select(fd + 1, &readSet, nil, nil, &tv)
+            if ready <= 0 { break }
+            if !fdIsSet(fd, set: &readSet) { continue }
+
+            var from = sockaddr_in()
+            var fromLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let received = buffer.withUnsafeMutableBufferPointer { buf -> ssize_t in
+                withUnsafeMutablePointer(to: &from) { fromPtr in
+                    fromPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                        recvfrom(fd, buf.baseAddress, buf.count, 0, sockPtr, &fromLen)
+                    }
+                }
+            }
+            guard received > 0 else { continue }
+            let data = Data(bytes: buffer, count: Int(received))
+
+            if let parsed = try? JSONDecoder().decode(JellyfinResponse.self, from: data),
+               let id = parsed.id, let name = parsed.name, let address = parsed.address {
+                if servers[id] == nil {
+                    servers[id] = Server(id: id, name: name, address: address, version: nil)
+                }
+            } else {
+                logger.debug("Ignoring non-Jellyfin UDP reply (\(received) bytes)")
+            }
+        }
+
+        return Array(servers.values).sorted { $0.name < $1.name }
+    }
+
+    enum DiscoveryError: Error, CustomStringConvertible {
+        case socketFailed(Int32)
+        case setsockoptFailed(Int32)
+        case bindFailed(Int32)
+        case sendFailed(Int32)
+
+        var description: String {
+            switch self {
+            case .socketFailed(let e): return "socket() failed: errno=\(e)"
+            case .setsockoptFailed(let e): return "setsockopt(SO_BROADCAST) failed: errno=\(e)"
+            case .bindFailed(let e): return "bind() failed: errno=\(e)"
+            case .sendFailed(let e): return "sendto() failed: errno=\(e)"
+            }
+        }
+    }
+}
+
+// MARK: - Cross-platform fd_set helpers
+// The `FD_SET`/`FD_ZERO`/`FD_ISSET` C macros aren't imported into Swift; these
+// implement the same bit-twiddling by hand. `fd_set` on macOS/Linux is an array
+// of __int32_t with FD_SETSIZE (typically 1024) bits.
+
+private func inaddr_any() -> in_addr_t { return 0 }
+
+private func fdZero(_ set: inout fd_set) {
+    withUnsafeMutablePointer(to: &set) {
+        memset($0, 0, MemoryLayout<fd_set>.size)
+    }
+}
+
+private func fdSet(_ fd: Int32, set: inout fd_set) {
+    let intOffset = Int(fd / 32)
+    let bitOffset = Int(fd % 32)
+    let mask: Int32 = 1 << bitOffset
+    withUnsafeMutablePointer(to: &set) { setPtr in
+        setPtr.withMemoryRebound(to: Int32.self, capacity: Int(FD_SETSIZE) / 32) { ptr in
+            ptr[intOffset] |= mask
+        }
+    }
+}
+
+private func fdIsSet(_ fd: Int32, set: inout fd_set) -> Bool {
+    let intOffset = Int(fd / 32)
+    let bitOffset = Int(fd % 32)
+    let mask: Int32 = 1 << bitOffset
+    return withUnsafeMutablePointer(to: &set) { setPtr in
+        setPtr.withMemoryRebound(to: Int32.self, capacity: Int(FD_SETSIZE) / 32) { ptr in
+            (ptr[intOffset] & mask) != 0
+        }
+    }
+}

--- a/Sources/NocturneServer/JellyfinService.swift
+++ b/Sources/NocturneServer/JellyfinService.swift
@@ -134,6 +134,29 @@ final class JellyfinService: Sendable {
 
     // MARK: - Images (admin proxy uses this for posters)
 
+    /// Fetch raw primary-image bytes for an item. Used by the poster cache / proxy.
+    /// - Parameters:
+    ///   - itemId: Jellyfin item ID
+    ///   - fillWidth: Optional `fillWidth` param for server-side resizing. Nil = original.
+    /// - Returns: Image bytes + the upstream Content-Type header.
+    func fetchPosterBytes(itemId: String, fillWidth: Int?) async throws -> (data: Data, contentType: String) {
+        var url = "\(baseURL)/Items/\(itemId)/Images/Primary"
+        if let w = fillWidth {
+            url += "?fillWidth=\(w)&quality=85"
+        }
+        var request = HTTPClientRequest(url: url)
+        request.method = .GET
+        request.headers.add(name: "Authorization", value: "MediaBrowser Token=\"\(apiKey)\"")
+        let response = try await httpClient.execute(request, timeout: .seconds(30))
+        guard response.status == .ok else {
+            throw JellyfinError.httpError(Int(response.status.code), "Poster fetch failed: \(response.status)")
+        }
+        let contentType = response.headers.first(name: "Content-Type") ?? "image/jpeg"
+        let buffer = try await response.body.collect(upTo: 10 * 1024 * 1024)
+        let data = Data(buffer: buffer)
+        return (data, contentType)
+    }
+
     func getImageUrl(for item: BaseItemDto, imageType: ImageType, quality: Int = 85) -> String? {
         if imageType == .backdrop {
             guard let backdropTags = item.backdropImageTags, !backdropTags.isEmpty else {

--- a/Sources/NocturneServer/PosterCache.swift
+++ b/Sources/NocturneServer/PosterCache.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Logging
+
+/// On-disk LRU cache for Jellyfin poster bytes.
+///
+/// Keyed by `"{jellyfinId}-{size}"`. Files are stored as `.bin` on disk; the
+/// original `Content-Type` is recorded in a sidecar `.ct` file so the response
+/// can echo it back (Jellyfin may return JPEG or WebP depending on `Accept`).
+///
+/// Eviction runs after every write: when total size exceeds `maxBytes`, files
+/// are deleted in order of oldest modification time until the cap is restored.
+final class PosterCache: @unchecked Sendable {
+    private let dir: URL
+    private let maxBytes: Int64
+    private let logger = Logger(label: "PosterCache")
+    private let lock = NSLock()
+
+    init(dir: String, maxBytes: Int64) throws {
+        self.dir = URL(fileURLWithPath: dir)
+        self.maxBytes = maxBytes
+        try FileManager.default.createDirectory(at: self.dir, withIntermediateDirectories: true)
+        logger.info("PosterCache at \(dir) (cap \(maxBytes) bytes)")
+    }
+
+    struct Entry {
+        let data: Data
+        let contentType: String
+    }
+
+    func get(key: String) -> Entry? {
+        let (binURL, ctURL) = urls(for: key)
+        guard FileManager.default.fileExists(atPath: binURL.path) else { return nil }
+        // Touch mtime so LRU treats this as hot.
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date()], ofItemAtPath: binURL.path)
+        guard let data = try? Data(contentsOf: binURL) else { return nil }
+        let contentType = (try? String(contentsOf: ctURL, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "image/jpeg"
+        return Entry(data: data, contentType: contentType)
+    }
+
+    func set(key: String, data: Data, contentType: String) {
+        let (binURL, ctURL) = urls(for: key)
+        do {
+            try data.write(to: binURL, options: .atomic)
+            try contentType.write(to: ctURL, atomically: true, encoding: .utf8)
+        } catch {
+            logger.warning("PosterCache write failed for \(key): \(error)")
+            return
+        }
+        evictIfNeeded()
+    }
+
+    // MARK: - Private
+
+    private func urls(for key: String) -> (bin: URL, ct: URL) {
+        // Sanitize: only allow [A-Za-z0-9_-] from the composed key.
+        let safe = key.unicodeScalars.map { scalar -> Character in
+            if CharacterSet.alphanumerics.contains(scalar) || scalar == "-" || scalar == "_" {
+                return Character(scalar)
+            }
+            return "_"
+        }.reduce(into: "") { $0.append($1) }
+        return (dir.appendingPathComponent("\(safe).bin"),
+                dir.appendingPathComponent("\(safe).ct"))
+    }
+
+    private func evictIfNeeded() {
+        lock.lock(); defer { lock.unlock() }
+        let fm = FileManager.default
+        let keys: [URLResourceKey] = [.fileSizeKey, .contentModificationDateKey]
+        guard let contents = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: keys) else { return }
+        let binFiles = contents.filter { $0.pathExtension == "bin" }
+        var files: [(url: URL, size: Int64, mtime: Date)] = []
+        var totalSize: Int64 = 0
+        for url in binFiles {
+            guard let values = try? url.resourceValues(forKeys: Set(keys)) else { continue }
+            let size = Int64(values.fileSize ?? 0)
+            let mtime = values.contentModificationDate ?? .distantPast
+            files.append((url, size, mtime))
+            totalSize += size
+        }
+        guard totalSize > maxBytes else { return }
+        // Oldest first, delete until under cap.
+        let sorted = files.sorted { $0.mtime < $1.mtime }
+        var current = totalSize
+        for (url, size, _) in sorted {
+            if current <= maxBytes { break }
+            try? fm.removeItem(at: url)
+            // Sidecar too.
+            let ct = url.deletingPathExtension().appendingPathExtension("ct")
+            try? fm.removeItem(at: ct)
+            current -= size
+        }
+        logger.info("PosterCache evicted to \(current) bytes (cap \(maxBytes))")
+    }
+}

--- a/frontend/nocturne-web/index.html
+++ b/frontend/nocturne-web/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Nocturne</title>
   </head>
-  <body class="bg-white text-neutral-900">
+  <body class="bg-bg text-text">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/nocturne-web/package-lock.json
+++ b/frontend/nocturne-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nocturne-web",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/eb-garamond": "^5.2.7",
         "framer-motion": "^11.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -759,6 +760,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/eb-garamond": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/eb-garamond/-/eb-garamond-5.2.7.tgz",
+      "integrity": "sha512-V42tTlHDbnDo0+lENnXKWMx63Llq6Gfl2l7ozkoeRQN60S0jm6hEgCLlOT/5YyKAN9QZ0e2ofpy0rGKlz9jBrw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/frontend/nocturne-web/package.json
+++ b/frontend/nocturne-web/package.json
@@ -9,20 +9,20 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/eb-garamond": "^5.2.7",
+    "framer-motion": "^11.0.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "framer-motion": "^11.0.0"
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "@tailwindcss/postcss": "^4.0.0",
     "tailwindcss": "^4.1.12",
     "typescript": "^5.8.3",
     "vite": "^7.1.3"
   }
 }
-

--- a/frontend/nocturne-web/src/App.tsx
+++ b/frontend/nocturne-web/src/App.tsx
@@ -1,64 +1,45 @@
-import { motion } from 'framer-motion';
 import { useEffect, useMemo, useRef, useState } from 'react';
-
-
-
-
-type Tag = { id?: string; slug: string; title: string }
-type Movie = { jellyfinId: string; title: string; year?: number; posterUrl?: string; tags?: Tag[]; needsReview?: boolean }
-type AdminMovieApi = { jellyfinId: string; title: string; year?: number; posterUrl?: string; tags: string[]; needsReview: boolean }
-type TagSuggestionApi = { id: string; jellyfinId: string; suggestedTags: string[]; confidence: number; reasoning?: string; status: string; createdAt?: string; resolvedAt?: string }
-type BackfillStatusApi = { running: boolean; total: number; processed: number; startedAt?: string; cancelled?: boolean }
-type MoodBuckets = Record<string, { title: string, description: string }>
-type SyncStatus = {
-  isRunning: boolean
-  lastSyncAt?: string
-  lastSyncDuration?: number
-  moviesFound: number
-  moviesUpdated: number
-  moviesDeleted: number
-  errors: string[]
-}
-type ImportProgress = {
-  total: number
-  processed: number
-  success: number
-  fail: number
-  running: boolean
-}
-
-const API = '/api/v1'
+import { api, fetchVersion as fetchVersionApi } from './lib/api';
+import type {
+  BackfillStatusApi,
+  ImportProgress,
+  MoodBuckets,
+  Movie,
+  OnboardingStatus,
+  TagSuggestionApi,
+} from './lib/types';
+import { Sidebar } from './components/Sidebar';
+import { MobileHeader } from './components/MobileHeader';
+import { LibraryView } from './views/LibraryView';
+import { MovieDetailPanel } from './components/MovieDetailPanel';
+import { AutoTagQueue } from './components/AutoTagQueue';
+import { BackfillProgress } from './components/BackfillProgress';
+import { SettingsView } from './views/SettingsView';
+import { OnboardingView } from './views/onboarding/OnboardingView';
+import { Spinner } from './ui/Spinner';
 
 export default function App() {
+  const [onboardingStatus, setOnboardingStatus] = useState<OnboardingStatus | null>(null)
+  const [bootstrapping, setBootstrapping] = useState(true)
   const [movies, setMovies] = useState<Movie[]>([])
   const [loading, setLoading] = useState(false)
   const [q, setQ] = useState('')
   const [mood, setMood] = useState('')
   const [moods, setMoods] = useState<MoodBuckets>({})
   const [editingMovie, setEditingMovie] = useState<Movie | null>(null)
-  const [showApiKeys, setShowApiKeys] = useState(false)
   const [autoTaggerOpen, setAutoTaggerOpen] = useState(false)
-  const [autoTagIndex, setAutoTagIndex] = useState(0)
-  const [autoTagging, setAutoTagging] = useState(false)
-  const [autoSuggestion, setAutoSuggestion] = useState<{ suggestions: string[]; confidence: number; reasoning?: string; suggestionId?: string } | null>(null)
   const [pendingSuggestions, setPendingSuggestions] = useState<TagSuggestionApi[]>([])
-  const [autoError, setAutoError] = useState<string | null>(null)
-  const [selectedAutoTags, setSelectedAutoTags] = useState<string[]>([])
   const [autoQueue, setAutoQueue] = useState<string[]>([])
-  const [currentAutoId, setCurrentAutoId] = useState<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [syncActive, setSyncActive] = useState(false)
   const syncTimerRef = useRef<number | null>(null)
   const syncStartTsRef = useRef<number | null>(null)
   const [importProg, setImportProg] = useState<ImportProgress | null>(null)
   // Removed old batch tagging flow to simplify UI
-  const importInputRef = useRef<HTMLInputElement>(null)
   const [version, setVersion] = useState<string>("")
   const [anthKeySet, setAnthKeySet] = useState(false)
   const [omdbKeySet, setOmdbKeySet] = useState(false)
   const [autoTagEnabled, setAutoTagEnabled] = useState(false)
-  const [anthInput, setAnthInput] = useState("")
-  const [omdbInput, setOmdbInput] = useState("")
   const [viewMode, setViewMode] = useState<'tile' | 'list'>(() => {
     const stored = typeof window !== 'undefined' ? window.localStorage.getItem('nocturne.viewMode') : null
     return stored === 'list' ? 'list' : 'tile'
@@ -73,50 +54,28 @@ export default function App() {
   const [editedPendingTags, setEditedPendingTags] = useState<Record<string, string[]>>({})
   const [pendingPickerId, setPendingPickerId] = useState<string | null>(null)
 
-  // Emoji map for moods (fallback to 🎬)
-  const moodEmojiMap = useMemo<Record<string, string>>(() => ({
-    // Genres / moods (add as many slugs as you like; case-insensitive checks below)
-    all: '🧺',
-    comedy: '😂',
-    funny: '😄',
-    humor: '🤣',
-    drama: '🎭',
-    thrillers: '😱',
-    thriller: '😱',
-    horror: '👻',
-    fantasy: '🪄',
-    history: '🏛️',
-    crime: '🕵️',
-    cartoon: '🐻',
-    cartoons: '🐻',
-    animation: '🎨',
-    action: '💥',
-    adventure: '🗺️',
-    romance: '💘',
-    scifi: '🚀',
-    sci_fi: '🚀',
-    sciencefiction: '🚀',
-    documentary: '🎬',
-    family: '👨‍👩‍👧‍👦',
-    kids: '🧸',
-    mystery: '🕵️‍♀️',
-    war: '🪖',
-    western: '🤠',
-    music: '🎵',
-    sport: '🏅',
-    sports: '🏅',
-  }), []);
-
-  function getMoodEmoji(slug: string, title?: string) {
-    const key = (slug || title || '').toLowerCase().replace(/\s+/g, '')
-    return moodEmojiMap[key] || '🎬'
+  async function bootstrap() {
+    try {
+      const status = await api.onboarding.status()
+      setOnboardingStatus(status)
+      if (status.configured) {
+        await Promise.all([fetchMoods(), fetchAllMovies(), fetchVersion(), fetchPendingSuggestions()])
+      } else {
+        // Still fetch mood taxonomy + version so the wizard has them if needed
+        await Promise.all([fetchMoods(), fetchVersion()])
+      }
+    } catch (e) {
+      console.error('Bootstrap failed', e)
+    } finally {
+      setBootstrapping(false)
+    }
   }
 
-  useEffect(() => { fetchMoods(); fetchAllMovies(); fetchVersion(); fetchPendingSuggestions() }, [])
+  useEffect(() => { bootstrap() }, [])
 
   async function fetchSettingsInfo() {
     try {
-      const info = await api<{ jellyfin_url: string; jellyfin_api_key_set: boolean; jellyfin_user_id: string; anthropic_key_set: boolean; omdb_key_set: boolean; enable_auto_tagging: boolean }>(`/settings/info`)
+      const info = await api.settings.info()
       setAnthKeySet(!!info.anthropic_key_set)
       setOmdbKeySet(!!info.omdb_key_set)
       setAutoTagEnabled(!!info.enable_auto_tagging)
@@ -125,14 +84,8 @@ export default function App() {
 
   useEffect(() => { if (settingsOpen) fetchSettingsInfo() }, [settingsOpen])
 
-  async function api<T>(path: string, init?: RequestInit): Promise<T> {
-    const res = await fetch(API + path, { headers: { 'Content-Type': 'application/json' }, ...init })
-    if (!res.ok) throw new Error(await res.text())
-    return res.json()
-  }
-
   async function fetchMoods() {
-    const data = await api<{ moods: MoodBuckets }>('/moods')
+    const data = await api.moods.list()
     setMoods(data.moods)
   }
 
@@ -140,7 +93,7 @@ export default function App() {
     setLoading(true)
     try {
       // Admin proxy: live Jellyfin fetch enriched with local tags + needs-review flag.
-      const data = await api<{ items: AdminMovieApi[]; totalCount: number }>(`/admin/movies?limit=10000&offset=0`)
+      const data = await api.movies.listAll()
       const mapped: Movie[] = data.items.map(it => ({
         jellyfinId: it.jellyfinId,
         title: it.title,
@@ -158,17 +111,13 @@ export default function App() {
   }
 
   async function fetchVersion() {
-    try {
-      const res = await fetch('/version', { headers: { 'Content-Type': 'application/json' } })
-      if (!res.ok) return
-      const j = await res.json()
-      if (j && typeof j.version === 'string') setVersion(j.version)
-    } catch {}
+    const v = await fetchVersionApi()
+    if (v) setVersion(v)
   }
 
   async function pollSyncStatusOnce() {
     try {
-      const status = await api<SyncStatus>("/sync/status");
+      const status = await api.sync.status();
       // setSyncStatus(status);
 
       const startedAt = syncStartTsRef.current || 0;
@@ -198,7 +147,7 @@ export default function App() {
       setSyncActive(true)
       syncStartTsRef.current = Date.now()
       // fire-and-forget start; show banner immediately and poll
-      fetch(API + '/sync/jellyfin', { method: 'POST', headers: { 'Content-Type': 'application/json' } }).catch(() => {})
+      api.sync.trigger()
       if (syncTimerRef.current) window.clearTimeout(syncTimerRef.current)
       pollSyncStatusOnce()
     } catch (error) {
@@ -209,10 +158,7 @@ export default function App() {
 
   async function saveTags(movie: Movie, selectedTags: string[]) {
     try {
-      await api(`/movies/${movie.jellyfinId}/tags`, {
-        method: 'PUT',
-        body: JSON.stringify({ tagSlugs: selectedTags, replaceAll: true })
-      })
+      await api.movies.updateTags(movie.jellyfinId, selectedTags, true)
       await fetchAllMovies()
       setEditingMovie(null)
     } catch (error: any) {
@@ -224,10 +170,7 @@ export default function App() {
   async function removeTag(movie: Movie, tagSlug: string) {
     try {
       const remainingTags = (movie.tags || []).filter(t => t.slug !== tagSlug).map(t => t.slug)
-      await api(`/movies/${movie.jellyfinId}/tags`, {
-        method: 'PUT',
-        body: JSON.stringify({ tagSlugs: remainingTags, replaceAll: true })
-      })
+      await api.movies.updateTags(movie.jellyfinId, remainingTags, true)
       await fetchAllMovies()
     } catch (error: any) {
       console.error('Failed to remove tag:', error)
@@ -235,77 +178,9 @@ export default function App() {
     }
   }
 
-  // Queues a Claude suggestion. Approval happens in the pending-suggestions review UI.
-  async function autoTag(movie: Movie) {
-    try {
-      setLoading(true)
-      await api(`/movies/${movie.jellyfinId}/auto-tag`, { method: 'POST', body: JSON.stringify({}) })
-      await fetchPendingSuggestions()
-      await fetchAllMovies()
-    } catch (error: any) {
-      console.error('Failed to auto-tag:', error)
-      let message = 'Failed to queue suggestion.'
-      if (error.message?.includes('429')) {
-        message = 'Anthropic API rate limit reached. Please wait a moment and try again.'
-      } else if (error.message?.includes('401') || error.message?.includes('Invalid API key')) {
-        message = 'Invalid Anthropic API key. Please check your API key settings.'
-      }
-      alert(message)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function suggestFor(jellyfinId: string) {
-    setAutoError(null)
-    setAutoSuggestion(null)
-    setAutoTagging(true)
-    try {
-      const resp = await api<TagSuggestionApi>(`/movies/${jellyfinId}/auto-tag`, {
-        method: 'POST',
-        body: JSON.stringify({})
-      })
-      if (currentAutoId !== jellyfinId) return
-      setAutoSuggestion({ suggestions: resp.suggestedTags, confidence: resp.confidence, reasoning: resp.reasoning, suggestionId: resp.id })
-      setSelectedAutoTags(resp.suggestedTags || [])
-    } catch (e: any) {
-      setAutoError(e.message || 'Failed to get suggestions')
-    } finally {
-      setAutoTagging(false)
-    }
-  }
-
-  // Auto-fetch suggestions whenever the target movie changes
-  useEffect(() => {
-    if (!autoTaggerOpen || !currentAutoId) return
-    setAutoError(null)
-    setAutoSuggestion(null)
-    setSelectedAutoTags([])
-    suggestFor(currentAutoId)
-  }, [currentAutoId, autoTaggerOpen])
-
-  async function applyFor(movie: Movie) {
-    if (!autoSuggestion) return
-    try {
-      // Approve the queued suggestion if we have one; otherwise write tags directly.
-      if (autoSuggestion.suggestionId) {
-        await api(`/admin/suggestions/${autoSuggestion.suggestionId}/approve`, { method: 'POST' })
-      } else {
-        await api(`/movies/${movie.jellyfinId}/tags`, {
-          method: 'PUT',
-          body: JSON.stringify({ tagSlugs: selectedAutoTags, replaceAll: false })
-        })
-      }
-      await fetchPendingSuggestions()
-      await fetchAllMovies()
-    } catch (e) {
-      console.error('Failed to save tags', e)
-    }
-  }
-
   async function fetchPendingSuggestions() {
     try {
-      const resp = await api<{ items: TagSuggestionApi[] }>(`/admin/suggestions?status=pending`)
+      const resp = await api.suggestions.listPending()
       setPendingSuggestions(resp.items)
     } catch (e) {
       console.error('Failed to fetch pending suggestions:', e)
@@ -314,11 +189,7 @@ export default function App() {
 
   async function approveSuggestion(id: string, overrideTags?: string[]) {
     try {
-      const init: RequestInit = { method: 'POST' }
-      if (overrideTags) {
-        init.body = JSON.stringify({ tags: overrideTags })
-      }
-      await api(`/admin/suggestions/${id}/approve`, init)
+      await api.suggestions.approve(id, overrideTags)
       setEditedPendingTags(prev => {
         const { [id]: _removed, ...rest } = prev
         return rest
@@ -333,7 +204,7 @@ export default function App() {
 
   async function rejectSuggestion(id: string) {
     try {
-      await api(`/admin/suggestions/${id}/reject`, { method: 'POST' })
+      await api.suggestions.reject(id)
       setEditedPendingTags(prev => {
         const { [id]: _removed, ...rest } = prev
         return rest
@@ -349,7 +220,7 @@ export default function App() {
 
   async function exportTags() {
     try {
-      const data = await api<Record<string, string[]>>('/data/export')
+      const data = await api.data.export()
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
@@ -382,7 +253,7 @@ export default function App() {
         const chunk: Record<string, any> = {}
         for (const k of chunkKeys) chunk[k] = map[k]
         try {
-          await api('/data/import', { method: 'POST', body: JSON.stringify({ map: chunk, replaceAll: true }) })
+          await api.data.import(chunk, true)
           success += chunkKeys.length
         } catch {
           fail += chunkKeys.length
@@ -401,11 +272,8 @@ export default function App() {
 
   async function saveOpenAIKey(key: string) {
     try {
-      await api('/settings/keys', { method: 'POST', body: JSON.stringify({ anthropic_api_key: key }) })
-      setShowApiKeys(false)
-      alert('Anthropic API key saved successfully!')
+      await api.settings.saveAnthropicKey(key)
       setAnthKeySet(true)
-      setAnthInput("")
     } catch (error) {
       console.error('Failed to save API key:', error)
       alert('Failed to save API key')
@@ -414,10 +282,8 @@ export default function App() {
 
   async function saveOmdbKey(key: string) {
     try {
-      await api('/settings/keys', { method: 'POST', body: JSON.stringify({ omdb_api_key: key }) })
-      alert('OMDb API key saved successfully!')
+      await api.settings.saveOmdbKey(key)
       setOmdbKeySet(true)
-      setOmdbInput("")
     } catch (error) {
       console.error('Failed to save OMDb API key:', error)
       alert('Failed to save OMDb API key')
@@ -428,7 +294,7 @@ export default function App() {
     const prev = autoTagEnabled
     setAutoTagEnabled(next)
     try {
-      await api('/settings/keys', { method: 'POST', body: JSON.stringify({ enable_auto_tagging: next }) })
+      await api.settings.setAutoTagging(next)
     } catch (error) {
       console.error('Failed to toggle auto-tagging:', error)
       setAutoTagEnabled(prev)
@@ -438,7 +304,7 @@ export default function App() {
 
   async function startBackfill() {
     try {
-      const status = await api<BackfillStatusApi>('/admin/auto-tag/backfill', { method: 'POST' })
+      const status = await api.backfill.start()
       setBackfillStatus(status)
       schedulePollBackfill()
     } catch (error) {
@@ -449,7 +315,7 @@ export default function App() {
 
   async function startReprocessAll() {
     try {
-      const status = await api<BackfillStatusApi>('/admin/auto-tag/reprocess-all', { method: 'POST' })
+      const status = await api.backfill.reprocessAll()
       setBackfillStatus(status)
       schedulePollBackfill()
     } catch (error) {
@@ -461,7 +327,7 @@ export default function App() {
   async function cancelBackfill() {
     if (!confirm('Stop the auto-tagger? The current movie will finish, but no more will be processed.')) return
     try {
-      const status = await api<BackfillStatusApi>('/admin/auto-tag/cancel', { method: 'POST' })
+      const status = await api.backfill.cancel()
       setBackfillStatus(status)
     } catch (error) {
       console.error('Failed to cancel:', error)
@@ -476,7 +342,7 @@ export default function App() {
 
   async function pollBackfillOnce() {
     try {
-      const status = await api<BackfillStatusApi>('/admin/auto-tag/backfill/status')
+      const status = await api.backfill.status()
       setBackfillStatus(status)
       if (status.running) {
         // Refresh the movie list periodically so newly-tagged rows appear without waiting for done.
@@ -498,7 +364,7 @@ export default function App() {
   useEffect(() => {
     (async () => {
       try {
-        const status = await api<BackfillStatusApi>('/admin/auto-tag/backfill/status')
+        const status = await api.backfill.status()
         if (status.running) {
           setBackfillStatus(status)
           schedulePollBackfill()
@@ -533,1343 +399,254 @@ export default function App() {
     return [...needsReview, ...untagged, ...tagged]
   }, [filtered])
   
-  const currentAutoMovie = useMemo(() => movies.find(m => m.jellyfinId === currentAutoId) || null, [movies, currentAutoId])
+  const moviesById = useMemo(() => {
+    const map = new Map<string, Movie>();
+    movies.forEach(m => map.set(m.jellyfinId, m));
+    return map;
+  }, [movies]);
   const moodCounts = useMemo(() => {
     const counts: Record<string, number> = {}
     movies.forEach(m => (m.tags||[]).forEach(t => { counts[t.slug] = (counts[t.slug]||0)+1 }))
     return counts
   }, [movies])
 
-  return (
-    <div className="min-h-screen bg-[#f3f4f8] text-[#0f1222]">
-      <div className="grid grid-cols-[72px_minmax(0,1fr)]">
-        {/* Useful Sidebar */}
-        <aside className="hidden sm:flex flex-col items-center gap-4 py-6 bg-white/70 backdrop-blur-xl border-r border-black/5 sticky top-0 h-screen overflow-y-auto">
+  const pendingSuggestionsPanel = pendingSuggestions.length > 0 ? (
+    <section className="px-5 lg:px-10 pt-5">
+      <div className="border border-border bg-bg">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <div>
+            <div className="text-[11px] uppercase tracking-widest text-muted">
+              Tags needing review ({pendingSuggestions.length})
+            </div>
+            <div className="text-[12px] text-text-dim mt-1">
+              Auto-tags are live. Approve to confirm, or reject to remove.
+            </div>
+          </div>
           <button
-            className="w-10 h-10 rounded-xl grid place-items-center bg-black text-white"
-            title="Home"
+            onClick={() => fetchPendingSuggestions()}
+            className="text-[10px] uppercase tracking-widest text-muted hover:text-text cursor-pointer"
           >
-            🏠
+            Refresh
           </button>
-          <button
-            className="w-10 h-10 rounded-xl grid place-items-center bg-black/5 hover:bg-black/10"
-            title="Settings"
-            onClick={() => setSettingsOpen(true)}
-          >
-            ⚙️
-          </button>
-        </aside>
+        </div>
         <div>
-          {/* Header */}
-          <header className="sticky top-0 z-40 border-b border-black/5 backdrop-blur-xl bg-white/80">
-            <div className="px-4 sm:px-8 py-6">
-              <div className="flex flex-col gap-6">
-                {/* Title */}
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h1 className="text-[28px] sm:text-[32px] font-semibold tracking-tight">
-                      Dashboard
-                    </h1>
-                    <p className="text-black/60 mt-1 text-sm">
-                      Find something to watch by mood ·{" "}
-                      {ordered.length.toLocaleString()} shown ·
-                      <span className="ml-1 text-emerald-700">
-                        Tagged {stats.tagged}
-                      </span>{" "}
-                      ·
-                      <span className="text-amber-700">
-                        Untagged {stats.untagged}
-                      </span>
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div
-                      role="group"
-                      aria-label="View mode"
-                      className="inline-flex items-center gap-1 p-1 rounded-full bg-black/5 border border-black/5"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => setViewMode('tile')}
-                        aria-pressed={viewMode === 'tile'}
-                        title="Tile view"
-                        aria-label="Tile view"
-                        className={`p-1.5 rounded-full transition flex items-center justify-center ${
-                          viewMode === 'tile'
-                            ? 'bg-white text-[#0f1222] shadow-sm'
-                            : 'text-black/50 hover:text-black'
-                        }`}
-                      >
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                          <rect x="3" y="3" width="7" height="7" rx="1.5" />
-                          <rect x="14" y="3" width="7" height="7" rx="1.5" />
-                          <rect x="3" y="14" width="7" height="7" rx="1.5" />
-                          <rect x="14" y="14" width="7" height="7" rx="1.5" />
-                        </svg>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setViewMode('list')}
-                        aria-pressed={viewMode === 'list'}
-                        title="List view"
-                        aria-label="List view"
-                        className={`p-1.5 rounded-full transition flex items-center justify-center ${
-                          viewMode === 'list'
-                            ? 'bg-white text-[#0f1222] shadow-sm'
-                            : 'text-black/50 hover:text-black'
-                        }`}
-                      >
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                          <circle cx="5" cy="6" r="1" fill="currentColor" stroke="none" />
-                          <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
-                          <circle cx="5" cy="18" r="1" fill="currentColor" stroke="none" />
-                          <path d="M9 6h12M9 12h12M9 18h12" />
-                        </svg>
-                      </button>
-                    </div>
-                    <button
-                      className="hidden sm:inline-flex px-4 py-2.5 bg-[#0f1222] hover:bg-black text-white rounded-full text-sm transition disabled:opacity-50"
-                      onClick={syncAll}
-                      disabled={loading}
-                    >
-                      {loading ? "Syncing…" : "Sync Library"}
-                    </button>
-                    <input
-                      ref={importInputRef}
-                      type="file"
-                      accept="application/json"
-                      hidden
-                      onChange={async (e) => {
-                        const file = e.target.files?.[0];
-                        if (file) await importTagsFile(file);
-                        if (e.target) e.target.value = "";
-                      }}
-                    />
-                  </div>
-                </div>
-
-                {/* Mood chips row */}
-                <div className="relative">
-                  <div className="pointer-events-none absolute left-0 top-0 h-full w-8 bg-gradient-to-r from-white to-transparent" />
-                  <div className="pointer-events-none absolute right-0 top-0 h-full w-8 bg-gradient-to-l from-white to-transparent" />
-                  <div className="flex gap-2 overflow-x-auto no-scrollbar py-1 px-1">
-                    <button
-                      onClick={() => setMood("")}
-                      className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-xs transition border shadow-sm hover:scale-[1.02] ${
-                        mood === ""
-                          ? "bg-gradient-to-r from-[#111827] to-[#0b1220] text-white border-transparent"
-                          : "bg-white/70 backdrop-blur border-black/10 text-[#0f1222] hover:bg-white"
-                      }`}
-                    >
-                      <span>🧺</span>
-                      <span>All</span>
-                    </button>
-                    {Object.entries(moods).map(([slug, info]) => (
-                      <button
-                        key={slug}
-                        onClick={() => setMood(slug)}
-                        className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-xs border whitespace-nowrap transition shadow-sm hover:scale-[1.02] ${
-                          mood === slug
-                            ? "bg-gradient-to-r from-indigo-600 to-fuchsia-600 text-white border-transparent"
-                            : "bg-white/70 backdrop-blur text-[#0f1222] border-black/10 hover:bg-white"
-                        }`}
-                      >
-                        <span>{getMoodEmoji(slug, info.title)}</span>
-                        <span>{info.title}</span>
-                        <span className="ml-1 opacity-70">
-                          {moodCounts[slug] || 0}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Search and quick actions */}
-                <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
-                  <div className="relative flex-1">
-                    <svg
-                      className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-black/40"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={1.5}
-                        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                      />
-                    </svg>
-                    <input
-                      className="w-full pl-12 pr-4 py-3 bg-white border border-black/10 rounded-full text-[#0f1222] placeholder-black/50 focus:outline-none focus:ring-2 focus:ring-black/10 focus:border-black/20 transition-all"
-                      placeholder="Search movies..."
-                      value={q}
-                      onChange={(e) => setQ(e.target.value)}
-                    />
-                  </div>
-                  <select
-                    className="px-4 py-3 bg-white border border-black/10 rounded-full text-[#0f1222] focus:outline-none focus:ring-2 focus:ring-black/10 focus:border-black/20 transition-all min-w-[160px]"
-                    value={mood}
-                    onChange={(e) => setMood(e.target.value)}
-                  >
-                    <option value="">All moods</option>
-                    {Object.entries(moods).map(([slug, m]) => (
-                      <option key={slug} value={slug}>
-                        {m.title}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-            </div>
-          </header>
-
-          {/* Auto-tag backfill progress */}
-          {backfillStatus?.running && (
-            <section className="px-3 sm:px-6 pt-4">
-              <div className="mx-auto w-full max-w-[1600px]">
-                <div className="rounded-2xl bg-emerald-50 ring-1 ring-emerald-200 px-4 py-3 flex items-center gap-3">
-                  <svg className="h-4 w-4 text-emerald-700 animate-spin flex-shrink-0" viewBox="0 0 24 24" fill="none">
-                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
-                    <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-                  </svg>
+          {pendingSuggestions.slice(0, 8).map((s) => {
+            const movie = movies.find((m) => m.jellyfinId === s.jellyfinId);
+            const currentTags = editedPendingTags[s.id] ?? s.suggestedTags;
+            const isEdited = editedPendingTags[s.id] !== undefined;
+            const addableTags = Object.keys(moods)
+              .filter((slug) => !currentTags.includes(slug))
+              .sort((a, b) => (moods[a]?.title || a).localeCompare(moods[b]?.title || b));
+            return (
+              <div key={s.id} className="flex flex-col sm:flex-row sm:items-start gap-3 px-5 py-3 border-t border-border first:border-t-0">
+                <div className="flex items-start gap-3 min-w-0 flex-1">
+                  {movie?.posterUrl && (
+                    <img src={movie.posterUrl} alt="" className="w-8 h-12 object-cover flex-shrink-0" />
+                  )}
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium text-emerald-900">
-                      Auto-tagging {backfillStatus.processed} / {backfillStatus.total} untagged movies…
-                    </div>
-                    <div className="text-[11px] text-emerald-800/70 mt-0.5">
-                      Claude is working in the background. Tags will appear as they come in.
-                    </div>
-                  </div>
-                  <div className="hidden sm:block w-40 h-2 rounded-full bg-emerald-200 overflow-hidden">
-                    <div
-                      className="h-full bg-emerald-600 transition-all"
-                      style={{ width: `${backfillStatus.total > 0 ? Math.min(100, (backfillStatus.processed / backfillStatus.total) * 100) : 0}%` }}
-                    />
-                  </div>
-                </div>
-              </div>
-            </section>
-          )}
-
-          {/* Pending Suggestions Queue */}
-          {pendingSuggestions.length > 0 && (
-            <section className="px-3 sm:px-6 pt-4">
-              <div className="mx-auto w-full max-w-[1600px]">
-                <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-4">
-                  <div className="flex items-center justify-between mb-3">
-                    <div>
-                      <div className="text-sm font-semibold text-[#0f1222]">
-                        Tags needing review ({pendingSuggestions.length})
-                      </div>
-                      <div className="text-[11px] text-black/50 mt-0.5">
-                        These tags are already live. Approve to confirm, or reject to remove them.
-                      </div>
-                    </div>
-                    <button
-                      className="text-xs text-black/60 hover:text-black"
-                      onClick={() => fetchPendingSuggestions()}
-                    >
-                      Refresh
-                    </button>
-                  </div>
-                  <div className="space-y-2">
-                    {pendingSuggestions.slice(0, 8).map(s => {
-                      const movie = movies.find(m => m.jellyfinId === s.jellyfinId)
-                      const currentTags = editedPendingTags[s.id] ?? s.suggestedTags
-                      const isEdited = editedPendingTags[s.id] !== undefined
-                      const addableTags = Object.keys(moods)
-                        .filter(slug => !currentTags.includes(slug))
-                        .sort((a, b) => (moods[a]?.title || a).localeCompare(moods[b]?.title || b))
-                      return (
-                        <div key={s.id} className="flex flex-col sm:flex-row sm:items-start gap-3 py-2 border-t border-black/5 first:border-t-0">
-                          <div className="flex items-start gap-3 min-w-0 flex-1">
-                            {movie?.posterUrl && (
-                              <img src={movie.posterUrl} alt="" className="w-8 h-12 object-cover rounded flex-shrink-0" />
-                            )}
-                            <div className="flex-1 min-w-0">
-                              <div className="text-sm font-medium truncate">{movie?.title || s.jellyfinId}</div>
-                              <div className="mt-1 flex flex-wrap items-center gap-1">
-                                {currentTags.map(slug => (
-                                  <span key={slug} className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-black/[0.04] text-[11px]">
-                                    {moods[slug]?.title || slug}
-                                    <button
-                                      className="text-black/40 hover:text-rose-600 leading-none text-sm"
-                                      onClick={() => setEditedPendingTags(prev => ({ ...prev, [s.id]: currentTags.filter(t => t !== slug) }))}
-                                      aria-label={`Remove ${moods[slug]?.title || slug}`}
-                                    >
-                                      ×
-                                    </button>
-                                  </span>
-                                ))}
-                                <div className="relative inline-block">
-                                  <button
-                                    className="text-[11px] px-2 py-0.5 rounded-full border border-dashed border-black/25 text-black/50 hover:text-black hover:border-black/40"
-                                    onClick={() => setPendingPickerId(pendingPickerId === s.id ? null : s.id)}
-                                  >
-                                    + Add
-                                  </button>
-                                  {pendingPickerId === s.id && addableTags.length > 0 && (
-                                    <div className="absolute z-20 mt-1 max-h-56 w-56 overflow-auto rounded-lg border border-black/10 bg-white shadow-lg py-1">
-                                      {addableTags.map(slug => (
-                                        <button
-                                          key={slug}
-                                          className="block w-full text-left px-3 py-1.5 text-xs hover:bg-black/[0.04]"
-                                          onClick={() => {
-                                            setEditedPendingTags(prev => ({ ...prev, [s.id]: [...currentTags, slug] }))
-                                            setPendingPickerId(null)
-                                          }}
-                                        >
-                                          {moods[slug]?.title || slug}
-                                        </button>
-                                      ))}
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                              <div className="text-[10px] text-black/40 mt-1">
-                                confidence {(s.confidence * 100).toFixed(0)}%
-                                {isEdited && <span className="ml-1 text-amber-600">· edited</span>}
-                              </div>
-                            </div>
-                          </div>
-                          <div className="flex gap-2 sm:flex-shrink-0">
-                            <button
-                              className="flex-1 sm:flex-none px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs disabled:opacity-50"
-                              onClick={() => approveSuggestion(s.id, isEdited ? currentTags : undefined)}
-                              disabled={currentTags.length === 0}
-                              title={currentTags.length === 0 ? 'Add at least one tag or reject instead' : undefined}
-                            >
-                              Approve
-                            </button>
-                            <button
-                              className="flex-1 sm:flex-none px-3 py-1.5 rounded-lg border border-black/10 hover:bg-black/5 text-xs"
-                              onClick={() => rejectSuggestion(s.id)}
-                            >
-                              Reject
-                            </button>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              </div>
-            </section>
-          )}
-
-          {/* Movies Grid */}
-          <main className="px-3 sm:px-6 py-6">
-            {viewMode === 'tile' ? (
-            <div className="mx-auto w-full max-w-[1600px] grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(140px,1fr))] sm:[grid-template-columns:repeat(auto-fill,minmax(180px,1fr))]">
-              {ordered.map((m, idx) => {
-                const chips = m.tags || [];
-                return (
-                  <motion.div
-                    key={m.jellyfinId}
-                    className="group"
-                    initial={{ opacity: 0, y: 12 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{
-                      delay: Math.min(idx * 0.015, 0.25),
-                      duration: 0.3,
-                      ease: "easeOut",
-                    }}
-                  >
-                    <motion.div
-                      whileHover={{ y: -3 }}
-                      className="rounded-[22px] overflow-hidden bg-white shadow-[0_18px_40px_-18px_rgba(16,24,40,0.35)] ring-1 ring-black/5"
-                    >
-                      <div className="relative aspect-[3/4]">
-                        <img
-                          className="w-full h-full object-cover"
-                          src={m.posterUrl || ""}
-                          alt={m.title}
-                          onError={(e) => {
-                            (e.target as HTMLImageElement).src =
-                              "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjMwMCIgdmlld0JveD0iMCAwIDIwMCAzMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMzAwIiBmaWxsPSIjRjNGNEY2Ii8+CjxwYXRoIGQ9Ik0xMDAgMTQwTDEzMCAxNjBIMTMwTDEwMCAxODBMNzAgMTYwSDcwTDEwMCAxNDBaIiBmaWxsPSIjRDFENUQ5Ii8+Cjx0ZXh0IHg9IjEwMCIgeT0iMjIwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjNjg3Mjc2IiBmb250LWZhbWlseT0ic3lzdGVtLXVpIiBmb250LXNpemU9IjE0Ij5ObyBQb3N0ZXI8L3RleHQ+Cjwvc3ZnPgo=";
-                          }}
-                        />
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
-                        {m.needsReview && (
-                          <span
-                            className="absolute top-2 left-2 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-500/95 text-white shadow"
-                            title="Auto-tagged with low confidence — please review."
+                    <div className="text-[13px] text-text truncate">{movie?.title || s.jellyfinId}</div>
+                    <div className="mt-1 flex flex-wrap items-center gap-1">
+                      {currentTags.map((slug) => (
+                        <span key={slug} className="inline-flex items-center gap-1 border border-border text-[10px] uppercase tracking-wider text-text-dim px-2 py-0.5">
+                          {moods[slug]?.title || slug}
+                          <button
+                            className="text-muted hover:text-text leading-none"
+                            onClick={() => setEditedPendingTags((prev) => ({ ...prev, [s.id]: currentTags.filter((t) => t !== slug) }))}
+                            aria-label={`Remove ${moods[slug]?.title || slug}`}
                           >
-                            Needs review
-                          </span>
-                        )}
-                      </div>
-                      {/* Details strip under image (not covering poster) */}
-                      <div className="p-3 border-t border-black/5">
-                        <h3
-                          className="text-[14px] font-semibold leading-tight truncate"
-                          title={m.title}
+                            ×
+                          </button>
+                        </span>
+                      ))}
+                      <div className="relative inline-block">
+                        <button
+                          className="text-[10px] uppercase tracking-wider px-2 py-0.5 border border-dashed border-border text-muted hover:text-text hover:border-border-hover cursor-pointer"
+                          onClick={() => setPendingPickerId(pendingPickerId === s.id ? null : s.id)}
                         >
-                          {m.title}
-                        </h3>
-                        {/* description removed */}
-                        <div className="mt-2 flex flex-wrap gap-1.5 min-h-[22px]">
-                          {chips.length === 0 ? (
-                            <span className="text-[11px] text-black/40 italic">
-                              No tags
-                            </span>
-                          ) : (
-                            chips.map((t) => (
-                              <span
-                                key={t.slug}
-                                className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[11px] bg-black/[0.06] text-[#0f1222] border border-black/5"
+                          + Add
+                        </button>
+                        {pendingPickerId === s.id && addableTags.length > 0 && (
+                          <div className="absolute z-20 mt-1 max-h-56 w-56 overflow-auto bg-bg border border-border py-1">
+                            {addableTags.map((slug) => (
+                              <button
+                                key={slug}
+                                className="block w-full text-left px-3 py-1.5 text-[12px] text-text hover:bg-surface cursor-pointer"
+                                onClick={() => {
+                                  setEditedPendingTags((prev) => ({ ...prev, [s.id]: [...currentTags, slug] }));
+                                  setPendingPickerId(null);
+                                }}
                               >
-                                <span>{getMoodEmoji(t.slug, t.title)}</span>
-                                {t.title}
-                              </span>
-                            ))
-                          )}
-                        </div>
-                        <div className="mt-3 flex gap-2">
-                          <button
-                            className="flex-1 text-[12px] font-medium py-2 rounded-full bg-[#0f1222] text-white hover:bg-black transition"
-                            onClick={() => setEditingMovie(m)}
-                          >
-                            Edit tags
-                          </button>
-                          <button
-                            className="hidden px-3 py-2 text-[12px] rounded-full bg-black/5"
-                            onClick={() => {
-                              const t = (m.tags || [])[0];
-                              if (t) removeTag(m, t.slug);
-                            }}
-                          >
-                            −
-                          </button>
-                          <button
-                            className="hidden px-3 py-2 text-[12px] rounded-full bg-black/5"
-                            onClick={() => autoTag(m)}
-                          >
-                            AI
-                          </button>
-                        </div>
-                      </div>
-                    </motion.div>
-                  </motion.div>
-                );
-              })}
-            </div>
-            ) : (
-            <div className="mx-auto w-full max-w-[1600px] rounded-2xl bg-white shadow-sm ring-1 ring-black/5 divide-y divide-black/5 overflow-hidden">
-              {ordered.map((m, idx) => {
-                const chips = m.tags || [];
-                return (
-                  <motion.div
-                    key={m.jellyfinId}
-                    initial={{ opacity: 0, y: 4 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{
-                      delay: Math.min(idx * 0.008, 0.2),
-                      duration: 0.2,
-                      ease: "easeOut",
-                    }}
-                    className="flex items-center gap-3 px-3 sm:px-4 py-2 hover:bg-black/[0.02] transition"
-                  >
-                    <img
-                      className="w-10 h-14 object-cover rounded-md bg-black/5 flex-shrink-0"
-                      src={m.posterUrl || ""}
-                      alt={m.title}
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).src =
-                          "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjMwMCIgdmlld0JveD0iMCAwIDIwMCAzMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMzAwIiBmaWxsPSIjRjNGNEY2Ii8+CjxwYXRoIGQ9Ik0xMDAgMTQwTDEzMCAxNjBIMTMwTDEwMCAxODBMNzAgMTYwSDcwTDEwMCAxNDBaIiBmaWxsPSIjRDFENUQ5Ii8+Cjx0ZXh0IHg9IjEwMCIgeT0iMjIwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjNjg3Mjc2IiBmb250LWZhbWlseT0ic3lzdGVtLXVpIiBmb250LXNpemU9IjE0Ij5ObyBQb3N0ZXI8L3RleHQ+Cjwvc3ZnPgo=";
-                      }}
-                    />
-                    <div className="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center sm:gap-3">
-                      <div className="min-w-0 sm:w-72 sm:flex-shrink-0">
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="text-[14px] font-medium truncate text-[#0f1222]"
-                            title={m.title}
-                          >
-                            {m.title}
-                            {m.year ? (
-                              <span className="ml-1 text-black/40 font-normal">
-                                ({m.year})
-                              </span>
-                            ) : null}
+                                {moods[slug]?.title || slug}
+                              </button>
+                            ))}
                           </div>
-                          {m.needsReview && (
-                            <span
-                              className="flex-shrink-0 px-1.5 py-0.5 rounded-full text-[9px] font-semibold bg-amber-500/95 text-white"
-                              title="Auto-tagged with low confidence — please review."
-                            >
-                              Review
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="mt-1 sm:mt-0 flex-1 min-w-0 flex flex-wrap items-center gap-1">
-                        {chips.length === 0 ? (
-                          <span className="text-[11px] text-black/40 italic">
-                            No tags
-                          </span>
-                        ) : (
-                          chips.map((t) => (
-                            <span
-                              key={t.slug}
-                              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-black/[0.06] text-[#0f1222] border border-black/5"
-                            >
-                              <span>{getMoodEmoji(t.slug, t.title)}</span>
-                              {t.title}
-                            </span>
-                          ))
                         )}
                       </div>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => setEditingMovie(m)}
-                      title="Edit tags"
-                      aria-label={`Edit tags for ${m.title}`}
-                      className="flex-shrink-0 p-2 rounded-full text-black/50 hover:text-black hover:bg-black/5 transition"
-                    >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.8"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M12 20h9" />
-                        <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
-                      </svg>
-                    </button>
-                  </motion.div>
-                );
-              })}
-            </div>
-            )}
-
-            {/* Empty State */}
-            {filtered.length === 0 && !loading && (
-              <div className="text-center py-20">
-                <div className="mx-auto w-20 h-20 bg-black/5 rounded-full flex items-center justify-center mb-6">
-                  <svg
-                    className="w-8 h-8 text-black/40"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M7 4V2a1 1 0 011-1h8a1 1 0 011 1v2m0 0h4a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V7a1 1 0 011-1h4m0-4v18m0 0H7m5 0h1"
-                    />
-                  </svg>
+                    <div className="text-[10px] uppercase tracking-widest text-muted mt-1">
+                      confidence {(s.confidence * 100).toFixed(0)}%
+                      {isEdited && <span className="ml-2 text-text-dim">· edited</span>}
+                    </div>
+                  </div>
                 </div>
-                <h3 className="text-xl font-light text-[#0f1222] mb-2">
-                  No movies found
-                </h3>
-                <p className="text-black/50 font-light">
-                  Try adjusting your search or filters, or sync your library.
-                </p>
+                <div className="flex gap-2 sm:flex-shrink-0">
+                  <button
+                    className="text-[10px] uppercase tracking-widest px-3 py-1.5 bg-text text-bg hover:bg-text-dim cursor-pointer disabled:opacity-40"
+                    onClick={() => approveSuggestion(s.id, isEdited ? currentTags : undefined)}
+                    disabled={currentTags.length === 0}
+                    title={currentTags.length === 0 ? 'Add at least one tag or reject instead' : undefined}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    className="text-[10px] uppercase tracking-widest px-3 py-1.5 border border-border hover:border-border-hover text-text cursor-pointer"
+                    onClick={() => rejectSuggestion(s.id)}
+                  >
+                    Reject
+                  </button>
+                </div>
               </div>
-            )}
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  ) : null;
 
-            {/* Loading State */}
-            {loading && movies.length === 0 && (
-              <div className="text-center py-20">
-                <div className="mx-auto w-16 h-16 border-4 border-black/10 border-t-black rounded-full animate-spin mb-6"></div>
-                <h3 className="text-xl font-light text-[#0f1222] mb-2">
-                  Loading movies...
-                </h3>
-                <p className="text-black/50 font-light">
-                  Please wait while we fetch your collection.
-                </p>
-              </div>
-            )}
-          </main>
+  if (bootstrapping) {
+    return (
+      <div className="min-h-screen bg-bg flex items-center justify-center">
+        <Spinner size={20} className="text-muted" />
+      </div>
+    );
+  }
+
+  if (!onboardingStatus?.configured) {
+    return <OnboardingView onFinished={bootstrap} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-bg text-text font-sans">
+      <MobileHeader onSettingsClick={() => setSettingsOpen(true)} />
+      <div className="flex">
+        <Sidebar onSettingsClick={() => setSettingsOpen(true)} version={version} />
+        <div className="flex-1 min-w-0">
+          <LibraryView
+            movies={ordered}
+            moods={moods}
+            moodCounts={moodCounts}
+            stats={stats}
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            searchQuery={q}
+            onSearchChange={setQ}
+            selectedMood={mood}
+            onMoodChange={setMood}
+            loading={loading}
+            onSync={syncAll}
+            onEditMovie={setEditingMovie}
+            backfillBanner={<BackfillProgress status={backfillStatus} />}
+            pendingSuggestionsPanel={pendingSuggestionsPanel}
+          />
         </div>
       </div>
 
       {/* Sync progress banner */}
       {syncActive && (
-        <div className="fixed bottom-3 left-1/2 -translate-x-1/2 z-[9999]">
-          <div className="px-4 py-2 rounded-full bg-white shadow-lg border border-black/10 text-sm text-[#0f1222] flex items-center gap-2">
-            <span className="inline-block w-3.5 h-3.5 border-2 border-black/20 border-t-black rounded-full animate-spin" />
-            <span>Syncing Jellyfin…</span>
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[9999]">
+          <div className="flex items-center gap-3 border border-border bg-bg px-4 py-2.5 shadow-lg">
+            <Spinner size={12} className="text-text" />
+            <span className="text-[11px] uppercase tracking-widest text-text">Syncing Jellyfin</span>
           </div>
         </div>
       )}
 
       {importProg && (
-        <div className="fixed bottom-3 left-1/2 -translate-x-1/2 z-50 w-[92%] sm:w-[640px] max-w-full rounded-2xl bg-white shadow-xl border border-black/10 p-4">
-          <div className="text-sm font-medium text-[#0f1222] mb-2">
-            Importing tags…
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-[92%] sm:w-[640px] max-w-full border border-border bg-bg shadow-lg p-5">
+          <div className="text-[11px] uppercase tracking-widest text-muted mb-3">Importing tags</div>
+          <div className="text-[11px] uppercase tracking-wider text-text-dim mb-3 flex gap-4">
+            <span>Total {importProg.total}</span>
+            <span>Processed {importProg.processed}</span>
+            <span>Success {importProg.success}</span>
+            <span>Failed {importProg.fail}</span>
           </div>
-          <div className="text-xs text-black/60 mb-2 flex gap-3">
-            <span>Identified: {importProg.total}</span>
-            <span>Processed: {importProg.processed}</span>
-            <span>Success: {importProg.success}</span>
-            <span>Failed: {importProg.fail}</span>
-          </div>
-          <div className="w-full h-2 rounded-full bg-black/10 overflow-hidden">
+          <div className="w-full h-[2px] bg-border overflow-hidden">
             <div
-              className="h-full bg-gradient-to-r from-indigo-600 to-fuchsia-600"
+              className="h-full bg-text transition-all"
               style={{
                 width: `${Math.min(
                   100,
-                  Math.round(
-                    (importProg.processed / Math.max(1, importProg.total)) * 100
-                  )
+                  Math.round((importProg.processed / Math.max(1, importProg.total)) * 100)
                 )}%`,
               }}
             />
           </div>
           {!importProg.running && (
-            <div className="mt-2 text-[11px] text-emerald-700">Completed</div>
+            <div className="mt-3 text-[10px] uppercase tracking-widest text-text-dim">Completed</div>
           )}
         </div>
       )}
 
-      {/* Settings Modal */}
-      {settingsOpen && (() => {
-        const untaggedCount = movies.filter(m => (m.tags || []).length === 0 && !m.needsReview).length
-        const reviewCount = pendingSuggestions.length
-        const autoTaggerQueue = untaggedCount + reviewCount
-        const backfillRunning = backfillStatus?.running === true
-        const backfillPct = backfillStatus && backfillStatus.total > 0
-          ? Math.min(100, Math.round((backfillStatus.processed / backfillStatus.total) * 100))
-          : 0
-        return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <div className="bg-white rounded-3xl p-5 max-w-2xl w-full mx-4 shadow-2xl border border-black/10 max-h-[85vh] overflow-y-auto">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Settings</h2>
-              <button
-                className="text-black/50 hover:text-black"
-                onClick={() => setSettingsOpen(false)}
-              >
-                ✕
-              </button>
-            </div>
-            <div className="space-y-8">
+      <SettingsView
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        movieCount={movies.length}
+        untaggedCount={movies.filter(m => (m.tags || []).length === 0 && !m.needsReview).length}
+        reviewCount={pendingSuggestions.length}
+        backfillStatus={backfillStatus}
+        anthKeySet={anthKeySet}
+        omdbKeySet={omdbKeySet}
+        autoTagEnabled={autoTagEnabled}
+        syncing={loading}
+        version={version}
+        onSync={() => { setSettingsOpen(false); syncAll(); }}
+        onStartBackfill={startBackfill}
+        onCancelBackfill={cancelBackfill}
+        onReprocessAll={startReprocessAll}
+        onSaveAnthKey={saveOpenAIKey}
+        onSaveOmdbKey={saveOmdbKey}
+        onToggleAutoTag={toggleAutoTagging}
+        onClearMovies={async () => {
+          try {
+            await api.settings.clearMovies();
+            setSettingsOpen(false);
+            await fetchAllMovies();
+          } catch {
+            alert('Failed to clear movies');
+          }
+        }}
+        onImportFile={importTagsFile}
+        onExportTags={exportTags}
+        onReviewUntaggedManually={() => {
+          const queue = movies.filter(m => (m.tags || []).length === 0).map(m => m.jellyfinId);
+          setAutoQueue(queue);
+          setAutoTaggerOpen(true);
+          setSettingsOpen(false);
+        }}
+      />
 
-              {/* ─────────── SECTION A: ACTIONS ─────────── */}
-              <div className="space-y-3">
-                <div className="text-[11px] uppercase tracking-wide text-black/50 font-semibold">Actions</div>
+      <MovieDetailPanel
+        movie={editingMovie}
+        moods={moods}
+        onSave={async (movie, selectedTags) => {
+          await saveTags(movie, selectedTags);
+        }}
+        onCancel={() => setEditingMovie(null)}
+      />
 
-                {/* Sync Library */}
-                <div className="rounded-2xl border border-black/10 p-4 bg-white">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-medium text-[#0f1222]">Sync Library</div>
-                      <p className="text-xs text-black/50 mt-1">
-                        Pull the latest movies from Jellyfin into Nocturne's catalog.
-                        {movies.length > 0 && <span className="block mt-0.5">{movies.length} movies in local catalog.</span>}
-                      </p>
-                    </div>
-                    <button
-                      className="shrink-0 px-4 py-2 rounded-lg bg-[#0f1222] text-white hover:bg-black disabled:opacity-50 text-sm"
-                      onClick={() => { setSettingsOpen(false); syncAll(); }}
-                      disabled={loading}
-                    >
-                      {loading ? 'Syncing…' : 'Sync now'}
-                    </button>
-                  </div>
-                </div>
+      <AutoTagQueue
+        open={autoTaggerOpen}
+        queue={autoQueue}
+        movieLookup={(id) => moviesById.get(id)}
+        moods={moods}
+        onComplete={() => setAutoTaggerOpen(false)}
+        onRefresh={async () => {
+          await Promise.all([fetchAllMovies(), fetchPendingSuggestions()]);
+        }}
+      />
 
-                {/* AI Auto-Tagger */}
-                <div className="rounded-2xl border border-black/10 p-4 bg-white">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-medium text-[#0f1222]">AI Auto-Tagger</div>
-                      <p className="text-xs text-black/50 mt-1">
-                        Tags untagged movies and re-reviews the ones flagged for review.
-                        {!anthKeySet && <span className="block mt-0.5 text-amber-600">Requires an Anthropic API key.</span>}
-                        {anthKeySet && !backfillRunning && (
-                          <span className="block mt-0.5">
-                            {untaggedCount} untagged · {reviewCount} in review
-                          </span>
-                        )}
-                      </p>
-                    </div>
-                    <button
-                      className="shrink-0 px-4 py-2 rounded-lg bg-[#0f1222] text-white hover:bg-black disabled:opacity-50 text-sm"
-                      onClick={async () => { await startBackfill() }}
-                      disabled={!anthKeySet || backfillRunning || autoTaggerQueue === 0}
-                    >
-                      {backfillRunning ? 'Running…' : 'Start auto-tag'}
-                    </button>
-                  </div>
-                  {backfillRunning && (
-                    <div className="mt-3">
-                      <div className="h-1.5 rounded-full bg-black/10 overflow-hidden">
-                        <div className="h-full bg-emerald-600 transition-all" style={{ width: `${backfillPct}%` }} />
-                      </div>
-                      <div className="mt-1.5 flex items-center justify-between gap-3">
-                        <span className="text-[11px] text-black/60">
-                          {backfillStatus?.processed ?? 0} / {backfillStatus?.total ?? 0} processed
-                          {backfillStatus?.cancelled && <span className="ml-2 text-rose-600">· cancelling…</span>}
-                        </span>
-                        {!backfillStatus?.cancelled && (
-                          <button
-                            className="text-[11px] text-rose-600 hover:text-rose-800 underline decoration-dotted underline-offset-2"
-                            onClick={cancelBackfill}
-                          >
-                            Cancel
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  <div className="mt-3 text-[11px]">
-                    <button
-                      className="text-black/50 hover:text-black underline decoration-dotted underline-offset-2"
-                      onClick={() => {
-                        const queue = movies.filter(m => (m.tags || []).length === 0).map(m => m.jellyfinId)
-                        setAutoQueue(queue); setAutoTagIndex(0); setCurrentAutoId(queue[0] || null); setAutoTaggerOpen(true); setSettingsOpen(false)
-                      }}
-                    >
-                      Review untagged manually instead →
-                    </button>
-                  </div>
-                </div>
 
-                {/* Reprocess All */}
-                <div className="rounded-2xl border border-black/10 p-4 bg-white">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-medium text-[#0f1222]">Reprocess all tagged movies</div>
-                      <p className="text-xs text-black/50 mt-1">
-                        Clear every movie's tags and re-run the auto-tagger against the whole library. Useful after taxonomy changes. Uses Anthropic API for every movie.
-                      </p>
-                    </div>
-                    <button
-                      className="shrink-0 px-4 py-2 rounded-lg border border-rose-300 text-rose-700 hover:bg-rose-50 disabled:opacity-50 text-sm"
-                      onClick={async () => {
-                        if (!confirm(`This will clear tags on all ${movies.length} movies and re-tag them with Claude. Continue?`)) return
-                        await startReprocessAll()
-                      }}
-                      disabled={!anthKeySet || backfillRunning || movies.length === 0}
-                    >
-                      Reprocess all
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              {/* ─────────── SECTION B: CONFIGURATION ─────────── */}
-              <div className="space-y-3">
-                <div className="text-[11px] uppercase tracking-wide text-black/50 font-semibold">Configuration</div>
-
-                {/* Jellyfin */}
-                <JellyfinSetup />
-
-                {/* API Keys */}
-                <div className="rounded-2xl border border-black/10 p-4 bg-white space-y-3">
-                  <div className="space-y-1">
-                    <label className="block text-xs text-black/60">Anthropic API Key</label>
-                    <div className="flex gap-2">
-                      <input id="anthropic-key-inline" className="flex-1 h-10 px-3 rounded-lg border border-black/10 focus:outline-none focus:ring-2 focus:ring-black/10" type="password" placeholder={anthKeySet && !anthInput ? '••••••••••••' : 'sk-ant-…'} value={anthInput} onChange={(e)=>setAnthInput(e.target.value)} onKeyDown={async (e)=>{ if(e.key==='Enter'){ const v=anthInput.trim(); if(v) await saveOpenAIKey(v) } }} />
-                      <button className="px-3 py-2 rounded-lg bg-[#0f1222] text-white hover:bg-black" onClick={async()=>{ const v=anthInput.trim(); if(v) await saveOpenAIKey(v) }}>Save</button>
-                    </div>
-                    <div className="text-[11px] text-black/50">Required for AI auto-tagging.</div>
-                  </div>
-                  <div className="space-y-1">
-                    <label className="block text-xs text-black/60">OMDb API Key</label>
-                    <div className="flex gap-2">
-                      <input id="omdb-key-inline" className="flex-1 h-10 px-3 rounded-lg border border-black/10 focus:outline-none focus:ring-2 focus:ring-black/10" type="password" placeholder={omdbKeySet && !omdbInput ? '••••••••••••' : 'omdb api key'} value={omdbInput} onChange={(e)=>setOmdbInput(e.target.value)} onKeyDown={async (e)=>{ if(e.key==='Enter'){ const v=omdbInput.trim(); if(v) await saveOmdbKey(v) } }} />
-                      <button className="px-3 py-2 rounded-lg bg-[#0f1222] text-white hover:bg-black" onClick={async()=>{ const v=omdbInput.trim(); if(v) await saveOmdbKey(v) }}>Save</button>
-                    </div>
-                    <div className="text-[11px] text-black/50">Optional: IMDb, Rotten Tomatoes and Metacritic ratings.</div>
-                  </div>
-                </div>
-
-                {/* Auto-tag on sync toggle */}
-                <div className="rounded-2xl border border-black/10 p-4 bg-white flex items-start justify-between gap-4">
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-[#0f1222]">Auto-tag on sync</div>
-                    <p className="text-xs text-black/50 mt-1">
-                      When on, new movies found during sync are queued for AI tagging automatically. Low-confidence suggestions are flagged for review.
-                      {!anthKeySet && <span className="block mt-1 text-amber-600">Requires an Anthropic API key.</span>}
-                    </p>
-                  </div>
-                  <button
-                    role="switch"
-                    aria-checked={autoTagEnabled}
-                    onClick={() => toggleAutoTagging(!autoTagEnabled)}
-                    disabled={!anthKeySet}
-                    className={`shrink-0 mt-1 inline-flex h-6 w-11 items-center rounded-full transition ${autoTagEnabled ? 'bg-emerald-600' : 'bg-black/20'} ${!anthKeySet ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  >
-                    <span className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${autoTagEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
-                  </button>
-                </div>
-              </div>
-
-              {/* ─────────── SECTION C: DATA / MAINTENANCE ─────────── */}
-              <div className="space-y-3">
-                <div className="text-[11px] uppercase tracking-wide text-black/50 font-semibold">Data & Maintenance</div>
-                <div className="rounded-2xl border border-black/10 p-4 bg-white space-y-3">
-                  <div className="flex flex-wrap gap-2">
-                    <button className="px-4 py-2 rounded-lg border border-black/10 hover:bg-black/5 text-sm" onClick={()=>importInputRef.current?.click()}>Import tags (JSON)</button>
-                    <button className="px-4 py-2 rounded-lg border border-black/10 hover:bg-black/5 text-sm" onClick={exportTags}>Export tags (JSON)</button>
-                    <input ref={importInputRef} type="file" accept="application/json" hidden onChange={async (e)=>{ const file=e.target.files?.[0]; if(file) await importTagsFile(file); if(e.target) e.target.value='' }} />
-                  </div>
-                  <div className="pt-3 border-t border-black/5">
-                    <button
-                      className="px-4 py-2 rounded-lg border border-rose-300 text-rose-700 hover:bg-rose-50 text-sm"
-                      onClick={async()=>{ if(!confirm('This will delete all movies from Nocturne (not Jellyfin) and reset tag usage counts. Continue?')) return; try { await api('/settings/clear-movies', { method: 'POST' }); setSettingsOpen(false); await fetchAllMovies(); } catch { alert('Failed to clear movies') } }}
-                    >
-                      Clear local movies
-                    </button>
-                    <p className="mt-1 text-[11px] text-black/50">Deletes local catalog and resets tag usage. Jellyfin untouched.</p>
-                  </div>
-                </div>
-              </div>
-
-              {version && <div className="pt-1 text-center text-xs text-black/50">{version}</div>}
-            </div>
-          </div>
-        </div>
-        )
-      })()}
-
-      {/* Edit Tags Modal */}
-      {editingMovie && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <div className="bg-white rounded-3xl p-5 sm:p-8 max-w-lg w-full mx-4 shadow-2xl border border-gray-100">
-            <div className="flex items-center justify-between mb-6 sm:mb-8">
-              <h2 className="text-xl sm:text-2xl font-light text-gray-900">Edit Tags</h2>
-              <button
-                className="text-gray-400 hover:text-gray-600 transition-colors rounded-full p-1 hover:bg-gray-100"
-                onClick={() => setEditingMovie(null)}
-              >
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
-
-            <div className="mb-6 sm:mb-8">
-              <h3 className="font-medium text-gray-900 mb-2">
-                {editingMovie.title}
-              </h3>
-              <p className="text-sm text-gray-500 mb-2">
-                Select up to 5 mood tags for this movie
-              </p>
-              <p className="text-xs text-gray-400">
-                💡 Uncheck all to leave the movie untagged
-              </p>
-            </div>
-
-            <EditTagsForm
-              movie={editingMovie}
-              availableMoods={moods}
-              onSave={(selectedTags) => saveTags(editingMovie, selectedTags)}
-              onCancel={() => setEditingMovie(null)}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* AI Auto Tagger Modal */}
-      {autoTaggerOpen && currentAutoMovie && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <div className="bg-white rounded-3xl p-4 sm:p-6 max-w-4xl w-full mx-4 shadow-2xl border border-gray-100">
-            <div className="flex flex-col sm:flex-row items-start gap-4 sm:gap-6">
-              <div className="w-full sm:w-1/3 aspect-[2/3] sm:aspect-auto bg-gray-100 rounded-2xl overflow-hidden">
-                <img
-                  src={currentAutoMovie.posterUrl || ""}
-                  alt={currentAutoMovie.title}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="flex-1 min-w-0 w-full">
-                <div className="flex items-start justify-between mb-3">
-                  <h2 className="text-xl font-light text-gray-900">
-                    {currentAutoMovie.title}
-                  </h2>
-                  <button
-                    className="text-gray-400 hover:text-gray-600 rounded-full p-1 hover:bg-gray-100"
-                    onClick={() => setAutoTaggerOpen(false)}
-                  >
-                    <svg
-                      className="w-6 h-6"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-                {/* Description intentionally not shown to keep frontend minimal */}
-
-                <div className="rounded-xl border border-gray-200 p-4 bg-gray-50">
-                  <div className="text-xs text-gray-500 mb-2">
-                    AI Suggestions
-                  </div>
-                  {autoTagging && (
-                    <div className="text-sm text-gray-600">
-                      Generating suggestions…
-                    </div>
-                  )}
-                  {autoError && (
-                    <div className="text-sm text-red-600">{autoError}</div>
-                  )}
-                  {autoSuggestion && (
-                    <div>
-                      <div className="flex flex-wrap gap-2 mb-3">
-                        {autoSuggestion.suggestions.map((s) => (
-                          <span
-                            key={s}
-                            className="px-2.5 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200"
-                          >
-                            {moods[s]?.title || s}
-                          </span>
-                        ))}
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        Confidence:{" "}
-                        {(autoSuggestion.confidence * 100).toFixed(0)}%
-                      </div>
-                      {autoSuggestion.reasoning && (
-                        <div className="text-xs text-gray-400 mt-1">
-                          {autoSuggestion.reasoning}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                {/* Editable selection */}
-                <div className="mt-4">
-                  <div className="text-xs text-gray-500 mb-2">
-                    Edit selection ({selectedAutoTags.length}/5)
-                  </div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-48 overflow-y-auto pr-1">
-                    {Object.entries(moods).map(([slug, mood]) => {
-                      const isSelected = selectedAutoTags.includes(slug);
-                      const disabled =
-                        !isSelected && selectedAutoTags.length >= 5;
-                      return (
-                        <label
-                          key={slug}
-                          className={`flex items-center gap-3 p-3 rounded-xl border text-sm transition ${
-                            isSelected
-                              ? "bg-blue-50 border-blue-200"
-                              : disabled
-                              ? "bg-gray-50 text-gray-400 border-gray-100 cursor-not-allowed"
-                              : "bg-white border-gray-200 hover:bg-gray-50"
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={isSelected}
-                            disabled={disabled}
-                            onChange={() => {
-                              setSelectedAutoTags((prev) => {
-                                if (prev.includes(slug))
-                                  return prev.filter((s) => s !== slug);
-                                if (prev.length >= 5) return prev;
-                                return [...prev, slug];
-                              });
-                            }}
-                            className="w-4 h-4"
-                          />
-                          <span className="text-gray-800">{mood.title}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                </div>
-
-                <div className="flex items-center justify-between mt-4">
-                  <div className="text-xs text-gray-400">
-                    {autoTagIndex + 1} / {autoQueue.length}
-                  </div>
-                  <div className="flex gap-2">
-                    <button
-                      className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full text-sm"
-                      onClick={() => {
-                        if (currentAutoId) {
-                          setAutoSuggestion(null);
-                          setSelectedAutoTags([]);
-                          suggestFor(currentAutoId);
-                        }
-                      }}
-                    >
-                      Regenerate
-                    </button>
-                    <button
-                      className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full text-sm"
-                      onClick={() => {
-                        // Reset edits to last AI suggestions
-                        if (autoSuggestion)
-                          setSelectedAutoTags(autoSuggestion.suggestions);
-                      }}
-                    >
-                      Reset
-                    </button>
-                    <button
-                      className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full text-sm"
-                      onClick={() => {
-                        // Skip
-                        const next = autoTagIndex + 1;
-                        if (next < autoQueue.length) {
-                          setAutoTagIndex(next);
-                          setAutoSuggestion(null);
-                          setSelectedAutoTags([]);
-                          setCurrentAutoId(autoQueue[next]);
-                        } else {
-                          setAutoTaggerOpen(false);
-                          setCurrentAutoId(null);
-                          setAutoSuggestion(null);
-                          setSelectedAutoTags([]);
-                        }
-                      }}
-                    >
-                      Skip
-                    </button>
-                    <button
-                      className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-full text-sm disabled:opacity-50"
-                      disabled={
-                        !autoSuggestion || selectedAutoTags.length === 0
-                      }
-                      onClick={async () => {
-                        if (!currentAutoMovie) return;
-                        await applyFor(currentAutoMovie);
-                        await fetchAllMovies();
-                        const next = autoTagIndex + 1;
-                        if (next < autoQueue.length) {
-                          setAutoTagIndex(next);
-                          setAutoSuggestion(null);
-                          setSelectedAutoTags([]);
-                          setCurrentAutoId(autoQueue[next]);
-                        } else {
-                          setAutoTaggerOpen(false);
-                          setCurrentAutoId(null);
-                          setAutoSuggestion(null);
-                          setSelectedAutoTags([]);
-                        }
-                      }}
-                    >
-                      Apply & Next
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* API Keys Modal */}
-      {showApiKeys && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <div className="bg-white rounded-3xl p-8 max-w-md w-full mx-4 shadow-2xl border border-gray-100">
-            <div className="flex items-center justify-between mb-8">
-              <h2 className="text-2xl font-light text-gray-900">
-                Anthropic API Key
-              </h2>
-              <button
-                className="text-gray-400 hover:text-gray-600 transition-colors rounded-full p-1 hover:bg-gray-100"
-                onClick={() => setShowApiKeys(false)}
-              >
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
-
-            <div className="mb-8">
-              <p className="text-sm text-gray-500 mb-4 font-light">
-                Enter your Anthropic API key to enable automatic movie tagging
-                with AI.
-              </p>
-              <a
-                href="https://console.anthropic.com/settings/keys"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:text-blue-700 text-sm font-medium"
-              >
-                Get your API key from Anthropic →
-              </a>
-            </div>
-
-            <ApiKeyForm
-              onSave={saveOpenAIKey}
-              onCancel={() => setShowApiKeys(false)}
-            />
-          </div>
-        </div>
-      )}
     </div>
   );
-}
-
-// Edit Tags Form Component
-function EditTagsForm({ movie, availableMoods, onSave, onCancel }: {
-  movie: Movie
-  availableMoods: MoodBuckets
-  onSave: (selectedTags: string[]) => void
-  onCancel: () => void
-}) {
-  const [selectedTags, setSelectedTags] = useState<string[]>(
-    (movie.tags || []).map(t => t.slug)
-  )
-  const [filter, setFilter] = useState('')
-
-  const handleTagToggle = (slug: string) => {
-    setSelectedTags(prev => {
-      if (prev.includes(slug)) {
-        return prev.filter(t => t !== slug)
-      } else if (prev.length < 5) {
-        return [...prev, slug]
-      }
-      return prev
-    })
-  }
-
-  return (
-    <div>
-      <div className="mb-4">
-        <input
-          className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-2xl text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition-all duration-200 font-light"
-          placeholder="Search moods..."
-          value={filter}
-          onChange={e => setFilter(e.target.value)}
-        />
-      </div>
-      <div className="space-y-3 mb-8 max-h-72 overflow-y-auto">
-        {Object.entries(availableMoods).filter(([slug, mood]) => {
-          const q = filter.toLowerCase()
-          if (!q) return true
-          return slug.toLowerCase().includes(q) || mood.title.toLowerCase().includes(q) || (mood.description||'').toLowerCase().includes(q)
-        }).map(([slug, mood]) => {
-          const isSelected = selectedTags.includes(slug)
-          const isDisabled = !isSelected && selectedTags.length >= 5
-          
-          return (
-            <label 
-              key={slug}
-              className={`flex items-center p-4 rounded-2xl border transition-all cursor-pointer ${
-                isSelected 
-                  ? 'bg-blue-50 border-blue-200 ring-1 ring-blue-200/50' 
-                  : isDisabled
-                    ? 'bg-gray-50 border-gray-100 text-gray-400 cursor-not-allowed'
-                    : 'bg-gray-50/50 border-gray-200 hover:border-gray-300 hover:bg-gray-50'
-              }`}
-            >
-              <input
-                type="checkbox"
-                checked={isSelected}
-                onChange={() => handleTagToggle(slug)}
-                disabled={isDisabled}
-                className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 focus:ring-2 focus:ring-offset-0"
-              />
-              <div className="ml-4 flex-1">
-                <div className="font-medium text-sm flex items-center justify-between">
-                  <span className="text-gray-900">{mood.title}</span>
-                  {(movie.tags || []).some(t => t.slug === slug) && !isSelected && (
-                    <span className="text-xs text-red-500 font-medium px-2 py-1 bg-red-50 rounded-full">Will remove</span>
-                  )}
-                  {!(movie.tags || []).some(t => t.slug === slug) && isSelected && (
-                    <span className="text-xs text-green-600 font-medium px-2 py-1 bg-green-50 rounded-full">Will add</span>
-                  )}
-                </div>
-                <div className="text-xs text-gray-500 font-light mt-1">{mood.description}</div>
-              </div>
-            </label>
-          )
-        })}
-      </div>
-      
-      <div className="flex gap-3">
-        <button
-          className="flex-1 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full font-medium transition-all duration-200"
-          onClick={() => onSave(selectedTags)}
-        >
-          {selectedTags.length === 0 ? 'Save (Untagged)' : `Save Tags (${selectedTags.length}/5)`}
-        </button>
-        <button
-          className="px-5 py-3 bg-red-50 hover:bg-red-100 text-red-600 border border-red-200 rounded-full font-medium transition-all duration-200 text-sm"
-          onClick={() => setSelectedTags([])}
-          title="Remove all tags"
-        >
-          Clear All
-        </button>
-        <button
-          className="px-6 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full font-medium transition-all duration-200"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  )
-}
-
-// API Key Form Component  
-function ApiKeyForm({ onSave, onCancel }: {
-  onSave: (key: string) => void
-  onCancel: () => void
-}) {
-  const [apiKey, setApiKey] = useState('')
-
-  return (
-    <div>
-      <div className="mb-8">
-        <input
-          type="password"
-          placeholder="sk-..."
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          className="w-full px-4 py-4 bg-gray-50 border border-gray-200 rounded-2xl text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition-all duration-200 font-light"
-        />
-      </div>
-      
-      <div className="flex gap-3">
-        <button
-          className="flex-1 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={() => onSave(apiKey)}
-          disabled={!apiKey.trim()}
-        >
-          Save API Key
-        </button>
-        <button
-          className="px-6 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full font-medium transition-all duration-200"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  )
-}
-
-// Jellyfin setup form
-function JellyfinSetup() {
-  const [url, setUrl] = useState('')
-  const [apiKey, setApiKey] = useState('')
-  const [testing, setTesting] = useState(false)
-  const [result, setResult] = useState<string | null>(null)
-  const [serverInfo, setServerInfo] = useState<{ serverName?: string; version?: string; localAddress?: string } | null>(null)
-
-  async function api<T>(path: string, init?: RequestInit): Promise<T> { // shadowed local helper
-    const res = await fetch('/api/v1' + path, { headers: { 'Content-Type': 'application/json' }, ...init })
-    if (!res.ok) throw new Error(await res.text())
-    return res.json()
-  }
-
-  // Prefill from server
-  useEffect(() => {
-    (async () => {
-      try {
-        const info = await api<{ jellyfin_url: string; jellyfin_api_key_set: boolean; jellyfin_user_id: string; anthropic_key_set: boolean }>(`/settings/info`)
-        setUrl(info.jellyfin_url || '')
-      } catch {}
-    })()
-  }, [])
-
-  async function testConnection() {
-    try {
-      setTesting(true)
-      // Trigger a real sync test against Jellyfin via the unified jellyfin endpoint.
-      // Saves as a side effect — use `/sync/test-connection` separately for a dry-run.
-      const r = await api<{ success: boolean; error?: string; userId?: string; serverName?: string; version?: string; localAddress?: string }>(
-        `/sync/test-connection`, { method: 'POST' }
-      )
-      if (r.success) {
-        setResult('Connection OK')
-        setServerInfo({ serverName: r.serverName, version: r.version, localAddress: r.localAddress })
-      } else {
-        setResult(r.error || 'Connection failed')
-        setServerInfo(null)
-      }
-    } catch (e: any) {
-      setResult(e.message || 'Failed')
-      setServerInfo(null)
-    } finally {
-      setTesting(false)
-    }
-  }
-
-  async function saveConfig() {
-    try {
-      const password = (document.getElementById('jf-pass') as HTMLInputElement)?.value || ''
-      const resp = await fetch('/api/v1/settings/jellyfin', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ jellyfin_url: url, jellyfin_username: apiKey, jellyfin_password: password })
-      })
-      const j = await resp.json()
-      if (j.success) {
-        setResult('Saved & authenticated')
-        setServerInfo({ serverName: j.serverName, version: j.version, localAddress: j.localAddress })
-      } else {
-        setResult(j.error || 'Save failed')
-      }
-    } catch (e: any) {
-      setResult(e.message || 'Save failed')
-    }
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="text-sm font-medium text-[#0f1222]">Jellyfin Setup</div>
-      {/* removed chips */}
-      <div className="grid grid-cols-1 gap-3">
-        <label className="text-xs text-black/60">Jellyfin URL</label>
-        <input className="px-4 py-3 rounded-2xl border border-black/10 focus:outline-none focus:ring-2 focus:ring-black/10" placeholder="http://192.168.0.111:8097" value={url} onChange={e=>setUrl(e.target.value)} />
-        <label className="text-xs text-black/60">Jellyfin Username</label>
-        <input className="px-4 py-3 rounded-2xl border border-black/10 focus:outline-none focus:ring-2 focus:ring-black/10" placeholder="Username" value={apiKey} onChange={e=>setApiKey(e.target.value)} />
-        <label className="text-xs text-black/60">Jellyfin Password (stored password will not be shown. You can enter a new one though.)</label>
-        <input id="jf-pass" className="px-4 py-3 rounded-2xl border border-black/10 focus:outline-none focus:ring-2 focus:ring-black/10" placeholder="Password" type="password" />
-      </div>
-      <div className="flex gap-2">
-        <button className="px-4 py-2.5 rounded-xl bg-black/5 hover:bg-black/10" onClick={testConnection} disabled={testing}>{testing ? 'Testing…' : 'Test Connection'}</button>
-        <button className="px-4 py-2.5 rounded-xl bg-[#0f1222] text-white hover:bg-black" onClick={saveConfig}>Save</button>
-      </div>
-      {result && (
-        <div className="text-sm">
-          <div className={result.includes('OK') ? 'text-emerald-700' : 'text-rose-700'}>{result}</div>
-          {serverInfo && (
-            <div className="mt-2 rounded-2xl border border-black/10 bg-black/[0.03] p-3 text-[12px] text-black/70">
-              <div><span className="font-medium text-black/80">Server</span>: {serverInfo.serverName}</div>
-              <div><span className="font-medium text-black/80">Version</span>: {serverInfo.version}</div>
-              <div><span className="font-medium text-black/80">Address</span>: {serverInfo.localAddress}</div>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  )
 }
  

--- a/frontend/nocturne-web/src/components/ApiKeyForm.tsx
+++ b/frontend/nocturne-web/src/components/ApiKeyForm.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+
+interface ApiKeyFormProps {
+  label: string;
+  placeholder: string;
+  helpText?: string;
+  isSet: boolean;
+  onSave: (key: string) => Promise<void>;
+}
+
+export function ApiKeyForm({ label, placeholder, helpText, isSet, onSave }: ApiKeyFormProps) {
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const effectivePlaceholder = isSet && !value ? '••••••••••••' : placeholder;
+
+  async function submit() {
+    const v = value.trim();
+    if (!v) return;
+    setBusy(true);
+    try {
+      await onSave(v);
+      setValue('');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2">
+        <div className="flex-1">
+          <Input
+            label={label}
+            type="password"
+            placeholder={effectivePlaceholder}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submit();
+            }}
+          />
+        </div>
+        <Button variant="primary" size="sm" onClick={submit} disabled={busy || !value.trim()}>
+          {busy ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+      {helpText && <p className="text-[11px] text-muted">{helpText}</p>}
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/components/AutoTagQueue.tsx
+++ b/frontend/nocturne-web/src/components/AutoTagQueue.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react';
+import { api, posterUrl } from '../lib/api';
+import { Button } from '../ui/Button';
+import { Dialog } from '../ui/Dialog';
+import { Spinner } from '../ui/Spinner';
+import type { MoodBuckets, Movie } from '../lib/types';
+
+interface AutoTagQueueProps {
+  open: boolean;
+  queue: string[]; // ordered jellyfinIds to process
+  movieLookup: (jellyfinId: string) => Movie | undefined;
+  moods: MoodBuckets;
+  onComplete: () => void;
+  onRefresh: () => Promise<void>;
+}
+
+const MAX_TAGS = 5;
+
+interface Suggestion {
+  suggestionId: string;
+  tags: string[];
+  confidence: number;
+  reasoning?: string;
+}
+
+export function AutoTagQueue({
+  open,
+  queue,
+  movieLookup,
+  moods,
+  onComplete,
+  onRefresh,
+}: AutoTagQueueProps) {
+  const [index, setIndex] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestion, setSuggestion] = useState<Suggestion | null>(null);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const currentId = queue[index];
+  const currentMovie = currentId ? movieLookup(currentId) : undefined;
+  const [posterFailed, setPosterFailed] = useState(false);
+
+  // Reset state when the modal opens or the target movie changes.
+  useEffect(() => {
+    if (!open || !currentId) return;
+    let cancelled = false;
+    setSuggestion(null);
+    setSelected([]);
+    setError(null);
+    setPosterFailed(false);
+    setLoading(true);
+    api.movies
+      .autoTag(currentId)
+      .then((resp) => {
+        if (cancelled) return;
+        setSuggestion({
+          suggestionId: resp.id,
+          tags: resp.suggestedTags,
+          confidence: resp.confidence,
+          reasoning: resp.reasoning,
+        });
+        setSelected(resp.suggestedTags);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : 'Failed to get suggestions');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, currentId]);
+
+  const toggle = (slug: string) => {
+    setSelected((prev) => {
+      if (prev.includes(slug)) return prev.filter((s) => s !== slug);
+      if (prev.length >= MAX_TAGS) return prev;
+      return [...prev, slug];
+    });
+  };
+
+  const advance = () => {
+    const next = index + 1;
+    if (next >= queue.length) {
+      onComplete();
+      setIndex(0);
+      return;
+    }
+    setIndex(next);
+  };
+
+  const applyAndAdvance = async () => {
+    if (!currentMovie || !suggestion) return;
+    try {
+      const isEdited = !arrayEq(selected, suggestion.tags);
+      if (isEdited) {
+        await api.movies.updateTags(currentMovie.jellyfinId, selected, false);
+      } else {
+        await api.suggestions.approve(suggestion.suggestionId);
+      }
+      await onRefresh();
+      advance();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save');
+    }
+  };
+
+  const regenerate = () => {
+    if (!currentId) return;
+    setSuggestion(null);
+    setSelected([]);
+    setError(null);
+    setLoading(true);
+    api.movies
+      .autoTag(currentId)
+      .then((resp) => {
+        setSuggestion({
+          suggestionId: resp.id,
+          tags: resp.suggestedTags,
+          confidence: resp.confidence,
+          reasoning: resp.reasoning,
+        });
+        setSelected(resp.suggestedTags);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to regenerate'))
+      .finally(() => setLoading(false));
+  };
+
+  if (!currentMovie) {
+    return (
+      <Dialog open={open} onClose={onComplete} title="Auto-tag queue" size="lg">
+        <p className="text-[13px] text-text-dim">Queue empty.</p>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onClose={onComplete} title={currentMovie.title} size="lg">
+      <div className="flex flex-col md:flex-row gap-6">
+        <div className="md:w-48 flex-shrink-0">
+          <div className="aspect-[2/3] bg-surface border border-border overflow-hidden">
+            {posterFailed ? (
+              <div className="w-full h-full flex items-center justify-center p-3 text-center">
+                <span className="font-serif italic text-base text-text leading-tight">{currentMovie.title}</span>
+              </div>
+            ) : (
+              <img
+                src={posterUrl(currentMovie.jellyfinId, 'medium')}
+                alt=""
+                onError={() => setPosterFailed(true)}
+                className="w-full h-full object-cover"
+              />
+            )}
+          </div>
+          <p className="text-[11px] uppercase tracking-widest text-muted mt-3">
+            {index + 1} / {queue.length}
+          </p>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          {loading && (
+            <div className="flex items-center gap-3 text-muted text-[13px]">
+              <Spinner size={14} />
+              Generating suggestions…
+            </div>
+          )}
+
+          {error && (
+            <div className="border border-border bg-surface px-4 py-3 text-[13px] text-text">
+              {error}
+            </div>
+          )}
+
+          {!loading && suggestion && (
+            <>
+              <div className="text-[10px] uppercase tracking-widest text-muted mb-2">
+                Suggestion · confidence {(suggestion.confidence * 100).toFixed(0)}%
+              </div>
+              {suggestion.reasoning && (
+                <p className="text-[13px] text-text-dim italic mb-4 leading-snug">
+                  {suggestion.reasoning}
+                </p>
+              )}
+
+              <div className="text-[10px] uppercase tracking-widest text-muted mb-2">
+                Edit selection ({selected.length} / {MAX_TAGS})
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-[1px] border border-border max-h-[40vh] overflow-y-auto">
+                {Object.entries(moods).map(([slug, mood]) => {
+                  const isSelected = selected.includes(slug);
+                  const disabled = !isSelected && selected.length >= MAX_TAGS;
+                  return (
+                    <label
+                      key={slug}
+                      className={`flex items-center gap-3 px-3 py-2 bg-bg cursor-pointer transition-colors ${
+                        isSelected ? 'bg-surface' : 'hover:bg-surface'
+                      } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        disabled={disabled}
+                        onChange={() => toggle(slug)}
+                        className="accent-text cursor-pointer"
+                      />
+                      <span className="text-[13px] text-text truncate">{mood.title}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          <div className="mt-6 flex flex-wrap items-center justify-end gap-2">
+            <Button variant="ghost" onClick={regenerate} size="sm" disabled={loading}>
+              Regenerate
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => suggestion && setSelected(suggestion.tags)}
+              size="sm"
+              disabled={!suggestion}
+            >
+              Reset
+            </Button>
+            <Button variant="line" onClick={advance} size="sm">
+              Skip
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={applyAndAdvance}
+              disabled={!suggestion || selected.length === 0 || loading}
+            >
+              Apply & next
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function arrayEq(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}

--- a/frontend/nocturne-web/src/components/BackfillProgress.tsx
+++ b/frontend/nocturne-web/src/components/BackfillProgress.tsx
@@ -1,0 +1,29 @@
+import { Spinner } from '../ui/Spinner';
+import type { BackfillStatusApi } from '../lib/types';
+
+interface BackfillProgressProps {
+  status: BackfillStatusApi | null;
+}
+
+export function BackfillProgress({ status }: BackfillProgressProps) {
+  if (!status?.running) return null;
+  const pct = status.total > 0 ? Math.min(100, (status.processed / status.total) * 100) : 0;
+  return (
+    <section className="px-5 lg:px-10 pt-5">
+      <div className="flex items-center gap-4 border border-border bg-surface px-5 py-4">
+        <Spinner size={14} className="text-text flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] text-text">
+            Auto-tagging {status.processed} / {status.total} untagged films…
+          </div>
+          <div className="text-[10px] uppercase tracking-widest text-muted mt-1">
+            {status.cancelled ? 'Cancelling…' : 'Claude is working in the background.'}
+          </div>
+        </div>
+        <div className="hidden md:block w-40 h-[2px] bg-border overflow-hidden">
+          <div className="h-full bg-text transition-all" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/nocturne-web/src/components/JellyfinConnectForm.tsx
+++ b/frontend/nocturne-web/src/components/JellyfinConnectForm.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Divider } from '../ui/Divider';
+
+interface JellyfinConnectFormProps {
+  /** Called on successful connection. Wizard uses this to advance. */
+  onConnected?: (info: { serverName?: string; version?: string; localAddress?: string }) => void;
+  /** If true, pre-fills URL + username from server (used in Settings). */
+  loadExisting?: boolean;
+}
+
+export function JellyfinConnectForm({ onConnected, loadExisting = false }: JellyfinConnectFormProps) {
+  const [url, setUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [serverInfo, setServerInfo] = useState<{ serverName?: string; version?: string; localAddress?: string } | null>(null);
+
+  useEffect(() => {
+    if (!loadExisting) return;
+    api.settings
+      .info()
+      .then((info) => {
+        if (info.jellyfin_url) setUrl(info.jellyfin_url);
+        if (info.jellyfin_username) setUsername(info.jellyfin_username);
+      })
+      .catch(() => {});
+  }, [loadExisting]);
+
+  async function testConnection() {
+    setBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const r = await api.sync.testConnection();
+      if (r.success) {
+        setStatus('Connection OK');
+        setServerInfo({ serverName: r.serverName, version: r.version, localAddress: r.localAddress });
+      } else {
+        setError(r.error || 'Connection failed');
+        setServerInfo(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Connection test failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const r = await api.settings.saveJellyfin(url.trim(), username.trim(), password);
+      if (r.success) {
+        setStatus('Saved & authenticated');
+        setServerInfo({ serverName: r.serverName, version: r.version, localAddress: r.localAddress });
+        setPassword('');
+        onConnected?.({ serverName: r.serverName, version: r.version, localAddress: r.localAddress });
+      } else {
+        setError(r.error || 'Save failed');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <Input label="Jellyfin URL" placeholder="http://192.168.1.24:8096" value={url} onChange={(e) => setUrl(e.target.value)} />
+      <Input label="Username" placeholder="admin" value={username} onChange={(e) => setUsername(e.target.value)} />
+      <Input
+        label={loadExisting ? 'Password (blank to keep existing)' : 'Password'}
+        type="password"
+        placeholder="••••••••"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+
+      {status && (
+        <div className="text-[11px] uppercase tracking-widest text-text-dim">{status}</div>
+      )}
+      {error && (
+        <div className="text-[13px] text-text border border-border bg-surface px-3 py-2">{error}</div>
+      )}
+      {serverInfo && (
+        <>
+          <Divider />
+          <div className="text-[11px] uppercase tracking-widest text-muted">Server</div>
+          <div className="text-[13px] text-text-dim">
+            {serverInfo.serverName}
+            {serverInfo.version && <> · Jellyfin {serverInfo.version}</>}
+            {serverInfo.localAddress && <> · {serverInfo.localAddress}</>}
+          </div>
+        </>
+      )}
+
+      <div className="flex gap-2 justify-end pt-2">
+        <Button variant="line" onClick={testConnection} disabled={busy} size="sm">
+          {busy ? 'Testing…' : 'Test connection'}
+        </Button>
+        <Button variant="primary" onClick={save} disabled={busy || !url || !username} size="sm">
+          {busy ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/components/MobileHeader.tsx
+++ b/frontend/nocturne-web/src/components/MobileHeader.tsx
@@ -1,0 +1,20 @@
+import { GearIcon } from './Sidebar';
+
+interface MobileHeaderProps {
+  onSettingsClick: () => void;
+}
+
+export function MobileHeader({ onSettingsClick }: MobileHeaderProps) {
+  return (
+    <header className="lg:hidden flex items-center justify-between px-5 h-14 border-b border-border bg-bg sticky top-0 z-30">
+      <span className="font-serif italic text-2xl text-text">Nocturne</span>
+      <button
+        onClick={onSettingsClick}
+        aria-label="Settings"
+        className="w-10 h-10 flex items-center justify-center text-muted hover:text-text transition-colors cursor-pointer"
+      >
+        <GearIcon size={20} />
+      </button>
+    </header>
+  );
+}

--- a/frontend/nocturne-web/src/components/MoodChips.tsx
+++ b/frontend/nocturne-web/src/components/MoodChips.tsx
@@ -1,0 +1,27 @@
+import { Chip } from '../ui/Chip';
+import type { MoodBuckets } from '../lib/types';
+
+interface MoodChipsProps {
+  moods: MoodBuckets;
+  counts: Record<string, number>;
+  selected: string; // '' = All
+  onSelect: (slug: string) => void;
+}
+
+export function MoodChips({ moods, counts, selected, onSelect }: MoodChipsProps) {
+  return (
+    <div className="fade-mask-x">
+      <div className="flex gap-2 overflow-x-auto no-scrollbar py-1 px-1">
+        <Chip active={selected === ''} onClick={() => onSelect('')}>
+          All
+        </Chip>
+        {Object.entries(moods).map(([slug, info]) => (
+          <Chip key={slug} active={selected === slug} onClick={() => onSelect(slug)}>
+            <span>{info.title}</span>
+            <span className="ml-1.5 opacity-50 tabular-nums">{counts[slug] || 0}</span>
+          </Chip>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/components/MovieDetailPanel.tsx
+++ b/frontend/nocturne-web/src/components/MovieDetailPanel.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from 'react';
+import { Button } from '../ui/Button';
+import { Dialog } from '../ui/Dialog';
+import { Input } from '../ui/Input';
+import type { MoodBuckets, Movie } from '../lib/types';
+
+interface MovieDetailPanelProps {
+  movie: Movie | null;
+  moods: MoodBuckets;
+  onSave: (movie: Movie, selectedTags: string[]) => void;
+  onCancel: () => void;
+}
+
+const MAX_TAGS = 5;
+
+export function MovieDetailPanel({ movie, moods, onSave, onCancel }: MovieDetailPanelProps) {
+  return (
+    <Dialog open={!!movie} onClose={onCancel} title={movie?.title} size="lg">
+      {movie && <EditForm key={movie.jellyfinId} movie={movie} moods={moods} onSave={onSave} onCancel={onCancel} />}
+    </Dialog>
+  );
+}
+
+function EditForm({
+  movie,
+  moods,
+  onSave,
+  onCancel,
+}: {
+  movie: Movie;
+  moods: MoodBuckets;
+  onSave: (movie: Movie, selectedTags: string[]) => void;
+  onCancel: () => void;
+}) {
+  const originalTags = useMemo(() => new Set((movie.tags || []).map((t) => t.slug)), [movie]);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(originalTags));
+  const [filter, setFilter] = useState('');
+
+  const toggle = (slug: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) {
+        next.delete(slug);
+      } else if (next.size < MAX_TAGS) {
+        next.add(slug);
+      }
+      return next;
+    });
+  };
+
+  const filtered = useMemo(() => {
+    const q = filter.toLowerCase().trim();
+    return Object.entries(moods).filter(([slug, mood]) => {
+      if (!q) return true;
+      return (
+        slug.toLowerCase().includes(q) ||
+        mood.title.toLowerCase().includes(q) ||
+        (mood.description || '').toLowerCase().includes(q)
+      );
+    });
+  }, [moods, filter]);
+
+  return (
+    <div>
+      {movie.year && (
+        <p className="text-[11px] uppercase tracking-widest text-muted mb-4">
+          {movie.year} · up to {MAX_TAGS} mood tags
+        </p>
+      )}
+
+      <Input
+        placeholder="Filter moods…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+
+      <div className="mt-5 flex flex-col border border-border max-h-[50vh] overflow-y-auto">
+        {filtered.length === 0 && (
+          <div className="px-4 py-8 text-center text-muted text-[13px]">No moods match.</div>
+        )}
+        {filtered.map(([slug, mood]) => {
+          const isSelected = selected.has(slug);
+          const wasOriginal = originalTags.has(slug);
+          const atCap = selected.size >= MAX_TAGS;
+          const disabled = !isSelected && atCap;
+          const willAdd = isSelected && !wasOriginal;
+          const willRemove = !isSelected && wasOriginal;
+          return (
+            <label
+              key={slug}
+              className={`flex items-start gap-3 px-4 py-3 border-b border-border last:border-b-0 cursor-pointer transition-colors ${
+                isSelected ? 'bg-surface' : 'bg-bg hover:bg-surface'
+              } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+            >
+              <input
+                type="checkbox"
+                checked={isSelected}
+                disabled={disabled}
+                onChange={() => toggle(slug)}
+                className="mt-[3px] accent-text cursor-pointer"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-[14px] text-text">{mood.title}</span>
+                  {willAdd && (
+                    <span className="text-[9px] uppercase tracking-widest text-text-dim">
+                      + Add
+                    </span>
+                  )}
+                  {willRemove && (
+                    <span className="text-[9px] uppercase tracking-widest text-muted">
+                      − Remove
+                    </span>
+                  )}
+                </div>
+                {mood.description && (
+                  <p className="text-[12px] text-text-dim mt-1 leading-snug line-clamp-2">
+                    {mood.description}
+                  </p>
+                )}
+              </div>
+            </label>
+          );
+        })}
+      </div>
+
+      <div className="mt-5 flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-widest text-muted">
+          {selected.size} / {MAX_TAGS} selected
+        </span>
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={() => setSelected(new Set())} size="sm">
+            Clear all
+          </Button>
+          <Button variant="line" onClick={onCancel} size="sm">
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => onSave(movie, Array.from(selected))} size="sm">
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/components/MovieGrid.tsx
+++ b/frontend/nocturne-web/src/components/MovieGrid.tsx
@@ -1,0 +1,30 @@
+import type { Movie } from '../lib/types';
+import { MovieTile } from './MovieTile';
+import { MovieListRow } from './MovieListRow';
+
+export type ViewMode = 'tile' | 'list';
+
+interface MovieGridProps {
+  movies: Movie[];
+  viewMode: ViewMode;
+  onEditMovie: (movie: Movie) => void;
+}
+
+export function MovieGrid({ movies, viewMode, onEditMovie }: MovieGridProps) {
+  if (viewMode === 'tile') {
+    return (
+      <div className="grid gap-5 md:gap-6 grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+        {movies.map((m) => (
+          <MovieTile key={m.jellyfinId} movie={m} onEdit={() => onEditMovie(m)} />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="border border-border bg-bg">
+      {movies.map((m) => (
+        <MovieListRow key={m.jellyfinId} movie={m} onEdit={() => onEditMovie(m)} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/components/MovieListRow.tsx
+++ b/frontend/nocturne-web/src/components/MovieListRow.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { posterUrl } from '../lib/api';
+import type { Movie } from '../lib/types';
+
+interface MovieListRowProps {
+  movie: Movie;
+  onEdit: () => void;
+}
+
+export function MovieListRow({ movie, onEdit }: MovieListRowProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const tags = movie.tags || [];
+  return (
+    <button
+      onClick={onEdit}
+      className="group w-full text-left flex items-center gap-4 px-4 lg:px-6 py-3 border-b border-border hover:bg-surface transition-colors cursor-pointer"
+    >
+      <div className="w-10 h-14 bg-surface border border-border flex-shrink-0 overflow-hidden">
+        {!imgFailed && (
+          <img
+            src={posterUrl(movie.jellyfinId, 'thumb')}
+            alt=""
+            loading="lazy"
+            onError={() => setImgFailed(true)}
+            className="w-full h-full object-cover"
+          />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[14px] text-text truncate">{movie.title}</span>
+          {movie.year ? <span className="text-muted text-[13px] flex-shrink-0">({movie.year})</span> : null}
+          {movie.needsReview && (
+            <span className="text-[9px] uppercase tracking-widest text-muted border border-border px-1.5 py-0.5 flex-shrink-0">
+              Review
+            </span>
+          )}
+        </div>
+        <div className="mt-1.5 flex flex-wrap gap-1.5 text-[10px] uppercase tracking-wider">
+          {tags.length === 0 ? (
+            <span className="text-muted italic normal-case tracking-normal text-[11px]">Untagged</span>
+          ) : (
+            tags.map((t) => (
+              <span
+                key={t.slug}
+                className="text-text-dim border border-border px-2 py-0.5"
+              >
+                {t.title}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+      <PencilIcon className="flex-shrink-0 text-muted group-hover:text-text transition-colors" />
+    </button>
+  );
+}
+
+function PencilIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+    </svg>
+  );
+}

--- a/frontend/nocturne-web/src/components/MovieTile.tsx
+++ b/frontend/nocturne-web/src/components/MovieTile.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { posterUrl } from '../lib/api';
+import type { Movie } from '../lib/types';
+
+interface MovieTileProps {
+  movie: Movie;
+  onEdit: () => void;
+}
+
+export function MovieTile({ movie, onEdit }: MovieTileProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const tags = movie.tags || [];
+  const visibleTags = tags.slice(0, 3);
+  const extra = tags.length - visibleTags.length;
+
+  return (
+    <button
+      onClick={onEdit}
+      className="group text-left cursor-pointer"
+      aria-label={`Edit tags for ${movie.title}`}
+    >
+      <div className="w-full aspect-[2/3] bg-surface border border-border group-hover:border-border-hover transition-colors overflow-hidden relative">
+        {imgFailed ? (
+          <div className="w-full h-full flex items-center justify-center p-4 text-center">
+            <span className="font-serif italic text-lg text-text leading-tight">{movie.title}</span>
+          </div>
+        ) : (
+          <img
+            src={posterUrl(movie.jellyfinId, 'medium')}
+            alt=""
+            loading="lazy"
+            onError={() => setImgFailed(true)}
+            className="w-full h-full object-cover"
+          />
+        )}
+        {movie.needsReview && (
+          <span className="absolute top-2 left-2 text-[9px] uppercase tracking-widest text-text bg-bg/90 px-2 py-0.5">
+            Review
+          </span>
+        )}
+      </div>
+      <div className="mt-2 min-h-[44px]">
+        <div className="text-[13px] text-text truncate" title={movie.title}>
+          {movie.title}
+          {movie.year ? <span className="text-muted ml-1.5">({movie.year})</span> : null}
+        </div>
+        <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0 text-[10px] uppercase tracking-wider">
+          {tags.length === 0 ? (
+            <span className="text-muted">Untagged</span>
+          ) : (
+            <>
+              {visibleTags.map((t) => (
+                <span key={t.slug} className="text-text-dim">
+                  {t.title}
+                </span>
+              ))}
+              {extra > 0 && <span className="text-muted">+{extra}</span>}
+            </>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/frontend/nocturne-web/src/components/Sidebar.tsx
+++ b/frontend/nocturne-web/src/components/Sidebar.tsx
@@ -1,0 +1,65 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+interface SidebarProps {
+  onSettingsClick: () => void;
+  version?: string;
+}
+
+export function Sidebar({ onSettingsClick, version }: SidebarProps) {
+  return (
+    <aside className="hidden lg:flex sticky top-0 h-screen w-[72px] flex-col items-center py-6 bg-bg border-r border-border">
+      <span
+        aria-label="Nocturne"
+        className="font-serif italic text-2xl text-text select-none"
+      >
+        N
+      </span>
+      <div className="flex-1" />
+      <SidebarButton label="Settings" onClick={onSettingsClick}>
+        <GearIcon />
+      </SidebarButton>
+      {version && (
+        <span className="text-[8px] uppercase tracking-widest text-muted mt-3">
+          v{version}
+        </span>
+      )}
+    </aside>
+  );
+}
+
+interface SidebarButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  children: ReactNode;
+}
+
+function SidebarButton({ label, children, className = '', ...props }: SidebarButtonProps) {
+  return (
+    <button
+      {...props}
+      title={label}
+      aria-label={label}
+      className={`w-10 h-10 flex items-center justify-center text-muted hover:text-text transition-colors cursor-pointer ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function GearIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/frontend/nocturne-web/src/index.css
+++ b/frontend/nocturne-web/src/index.css
@@ -1,8 +1,47 @@
 @import "tailwindcss";
 
+@theme {
+  /* Direction — Editorial Light (paper off-white, warm stone neutrals) */
+  --color-bg: #fafaf9;
+  --color-surface: #f5f5f4;
+  --color-border: #e7e5e4;
+  --color-border-hover: #d6d3d1;
+  --color-muted: #78716c;
+  --color-text: #0c0a09;
+  --color-text-dim: #44403c;
+
+  --font-serif: "EB Garamond", Georgia, serif;
+  --font-sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+
+  --radius-DEFAULT: 0px;
+  --radius-xs: 0px;
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-xl: 0px;
+  --radius-2xl: 0px;
+  --radius-3xl: 0px;
+
+  --tracking-wider: 0.12em;
+  --tracking-widest: 0.18em;
+}
+
 html, body, #root { height: 100%; }
-body { margin: 0; }
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
 /* Utilities */
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* Horizontal scroll fade masks for chip rows */
+.fade-mask-x {
+  mask-image: linear-gradient(to right, transparent, #000 16px, #000 calc(100% - 16px), transparent);
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 16px, #000 calc(100% - 16px), transparent);
+}

--- a/frontend/nocturne-web/src/lib/api.ts
+++ b/frontend/nocturne-web/src/lib/api.ts
@@ -1,0 +1,124 @@
+import type {
+  AdminMovieApi,
+  BackfillStatusApi,
+  DiscoveredServer,
+  JellyfinConnectResult,
+  JellyfinTestResult,
+  MoodBuckets,
+  OnboardingStatus,
+  SettingsInfo,
+  SyncStatus,
+  TagSuggestionApi,
+} from './types';
+
+const API = '/api/v1';
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(API + path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json() as Promise<T>;
+}
+
+function get<T>(path: string): Promise<T> {
+  return request<T>(path, { method: 'GET' });
+}
+
+function post<T = unknown>(path: string, body?: unknown): Promise<T> {
+  return request<T>(path, {
+    method: 'POST',
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function put<T = unknown>(path: string, body?: unknown): Promise<T> {
+  return request<T>(path, {
+    method: 'PUT',
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+// Fire-and-forget; doesn't throw on non-2xx. For endpoints where the caller
+// intentionally doesn't await (e.g. starting a sync + polling its status).
+function postVoid(path: string): void {
+  fetch(API + path, { method: 'POST', headers: { 'Content-Type': 'application/json' } }).catch(
+    () => {},
+  );
+}
+
+export const api = {
+  moods: {
+    list: () => get<{ moods: MoodBuckets }>('/moods'),
+  },
+  movies: {
+    listAll: (limit = 10000, offset = 0) =>
+      get<{ items: AdminMovieApi[]; totalCount: number }>(
+        `/admin/movies?limit=${limit}&offset=${offset}`,
+      ),
+    updateTags: (jellyfinId: string, tagSlugs: string[], replaceAll: boolean) =>
+      put(`/movies/${jellyfinId}/tags`, { tagSlugs, replaceAll }),
+    autoTag: (jellyfinId: string) =>
+      post<TagSuggestionApi>(`/movies/${jellyfinId}/auto-tag`, {}),
+  },
+  suggestions: {
+    listPending: () =>
+      get<{ items: TagSuggestionApi[] }>('/admin/suggestions?status=pending'),
+    approve: (id: string, overrideTags?: string[]) =>
+      post(`/admin/suggestions/${id}/approve`, overrideTags ? { tags: overrideTags } : undefined),
+    reject: (id: string) => post(`/admin/suggestions/${id}/reject`),
+  },
+  settings: {
+    info: () => get<SettingsInfo>('/settings/info'),
+    saveAnthropicKey: (key: string) => post('/settings/keys', { anthropic_api_key: key }),
+    saveOmdbKey: (key: string) => post('/settings/keys', { omdb_api_key: key }),
+    setAutoTagging: (enabled: boolean) => post('/settings/keys', { enable_auto_tagging: enabled }),
+    clearMovies: () => post('/settings/clear-movies'),
+    saveJellyfin: (url: string, username: string, password: string) =>
+      post<JellyfinConnectResult>('/settings/jellyfin', {
+        jellyfin_url: url,
+        jellyfin_username: username,
+        jellyfin_password: password,
+      }),
+  },
+  sync: {
+    status: () => get<SyncStatus>('/sync/status'),
+    trigger: () => postVoid('/sync/jellyfin'),
+    testConnection: () => post<JellyfinTestResult>('/sync/test-connection'),
+  },
+  jellyfin: {
+    discover: () => post<{ servers: DiscoveredServer[] }>('/jellyfin/discover'),
+  },
+  onboarding: {
+    status: () => get<OnboardingStatus>('/onboarding/status'),
+  },
+  backfill: {
+    start: () => post<BackfillStatusApi>('/admin/auto-tag/backfill'),
+    reprocessAll: () => post<BackfillStatusApi>('/admin/auto-tag/reprocess-all'),
+    cancel: () => post<BackfillStatusApi>('/admin/auto-tag/cancel'),
+    status: () => get<BackfillStatusApi>('/admin/auto-tag/backfill/status'),
+  },
+  data: {
+    export: () => get<Record<string, string[]>>('/data/export'),
+    import: (map: Record<string, unknown>, replaceAll: boolean) =>
+      post('/data/import', { map, replaceAll }),
+  },
+};
+
+// Build a URL for the poster proxy. Returns image bytes (or 404 → img onError).
+export function posterUrl(jellyfinId: string, size: 'thumb' | 'medium' | 'full' = 'medium'): string {
+  return `${API}/movies/${encodeURIComponent(jellyfinId)}/poster?size=${size}`;
+}
+
+// Version endpoint lives outside the /api/v1 prefix.
+export async function fetchVersion(): Promise<string | null> {
+  try {
+    const res = await fetch('/version', { headers: { 'Content-Type': 'application/json' } });
+    if (!res.ok) return null;
+    const j = (await res.json()) as { version?: string };
+    return typeof j.version === 'string' ? j.version : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/nocturne-web/src/lib/types.ts
+++ b/frontend/nocturne-web/src/lib/types.ts
@@ -1,0 +1,99 @@
+export type Tag = { id?: string; slug: string; title: string };
+
+export type Movie = {
+  jellyfinId: string;
+  title: string;
+  year?: number;
+  posterUrl?: string;
+  tags?: Tag[];
+  needsReview?: boolean;
+};
+
+export type AdminMovieApi = {
+  jellyfinId: string;
+  title: string;
+  year?: number;
+  posterUrl?: string;
+  tags: string[];
+  needsReview: boolean;
+};
+
+export type TagSuggestionApi = {
+  id: string;
+  jellyfinId: string;
+  suggestedTags: string[];
+  confidence: number;
+  reasoning?: string;
+  status: string;
+  createdAt?: string;
+  resolvedAt?: string;
+};
+
+export type BackfillStatusApi = {
+  running: boolean;
+  total: number;
+  processed: number;
+  startedAt?: string;
+  cancelled?: boolean;
+};
+
+export type MoodBuckets = Record<string, { title: string; description: string }>;
+
+export type SyncStatus = {
+  isRunning: boolean;
+  lastSyncAt?: string;
+  lastSyncDuration?: number;
+  moviesFound: number;
+  moviesUpdated: number;
+  moviesDeleted: number;
+  errors: string[];
+};
+
+export type ImportProgress = {
+  total: number;
+  processed: number;
+  success: number;
+  fail: number;
+  running: boolean;
+};
+
+export type SettingsInfo = {
+  jellyfin_url: string;
+  jellyfin_api_key_set: boolean;
+  jellyfin_user_id: string;
+  jellyfin_username?: string;
+  anthropic_key_set: boolean;
+  omdb_key_set: boolean;
+  enable_auto_tagging: boolean;
+};
+
+export type JellyfinTestResult = {
+  success: boolean;
+  error?: string;
+  userId?: string;
+  serverName?: string;
+  version?: string;
+  localAddress?: string;
+};
+
+export type JellyfinConnectResult = {
+  success: boolean;
+  error?: string;
+  serverName?: string;
+  version?: string;
+  localAddress?: string;
+};
+
+export type DiscoveredServer = {
+  id: string;
+  name: string;
+  address: string;
+  version?: string;
+};
+
+export type OnboardingStatus = {
+  configured: boolean;
+  has_jellyfin: boolean;
+  has_anthropic_key: boolean;
+  has_omdb_key: boolean;
+};

--- a/frontend/nocturne-web/src/main.tsx
+++ b/frontend/nocturne-web/src/main.tsx
@@ -1,5 +1,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import '@fontsource/eb-garamond/400.css'
+import '@fontsource/eb-garamond/400-italic.css'
+import '@fontsource/eb-garamond/500.css'
 import './index.css'
 import App from './App.tsx'
 

--- a/frontend/nocturne-web/src/ui/Button.tsx
+++ b/frontend/nocturne-web/src/ui/Button.tsx
@@ -1,0 +1,27 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+type Variant = 'primary' | 'line' | 'ghost';
+type Size = 'sm' | 'md';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+}
+
+const base =
+  'inline-flex items-center justify-center font-medium uppercase tracking-wider transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer select-none';
+
+const sizes: Record<Size, string> = {
+  sm: 'text-[10.5px] px-3 py-1.5',
+  md: 'text-[11.5px] px-4 py-2',
+};
+
+const variants: Record<Variant, string> = {
+  primary: 'bg-text text-bg hover:bg-text-dim',
+  line: 'bg-transparent text-text border border-border hover:border-border-hover',
+  ghost: 'bg-transparent text-muted hover:text-text',
+};
+
+export function Button({ variant = 'primary', size = 'md', className = '', ...props }: ButtonProps) {
+  return <button {...props} className={`${base} ${sizes[size]} ${variants[variant]} ${className}`} />;
+}

--- a/frontend/nocturne-web/src/ui/Card.tsx
+++ b/frontend/nocturne-web/src/ui/Card.tsx
@@ -1,0 +1,14 @@
+import type { HTMLAttributes } from 'react';
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  padded?: boolean;
+}
+
+export function Card({ padded = true, className = '', ...props }: CardProps) {
+  return (
+    <div
+      {...props}
+      className={`bg-surface border border-border ${padded ? 'p-5' : ''} ${className}`}
+    />
+  );
+}

--- a/frontend/nocturne-web/src/ui/Chip.tsx
+++ b/frontend/nocturne-web/src/ui/Chip.tsx
@@ -1,0 +1,17 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+interface ChipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  active?: boolean;
+}
+
+export function Chip({ active = false, className = '', ...props }: ChipProps) {
+  const activeCls = active
+    ? 'bg-text text-bg border-text'
+    : 'bg-transparent text-text-dim border-border hover:border-border-hover hover:text-text';
+  return (
+    <button
+      {...props}
+      className={`whitespace-nowrap uppercase tracking-wider text-[10px] px-3 py-1 border transition-colors cursor-pointer select-none ${activeCls} ${className}`}
+    />
+  );
+}

--- a/frontend/nocturne-web/src/ui/Dialog.tsx
+++ b/frontend/nocturne-web/src/ui/Dialog.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+
+type Size = 'sm' | 'md' | 'lg';
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  size?: Size;
+  title?: string;
+  children: ReactNode;
+}
+
+const maxWidths: Record<Size, string> = {
+  sm: 'lg:max-w-md',
+  md: 'lg:max-w-lg',
+  lg: 'lg:max-w-2xl',
+};
+
+export function Dialog({ open, onClose, size = 'md', title, children }: DialogProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex lg:items-center lg:justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+        className={`relative w-full h-full lg:h-auto ${maxWidths[size]} bg-surface border-0 lg:border border-border flex flex-col max-h-screen lg:max-h-[85vh]`}
+      >
+        {title && (
+          <div className="flex items-center justify-between px-5 lg:px-6 py-4 border-b border-border">
+            <h2 className="font-serif italic text-lg lg:text-xl text-text">{title}</h2>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="text-muted hover:text-text text-xl leading-none cursor-pointer"
+            >
+              ×
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-y-auto px-5 lg:px-6 py-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/ui/Divider.tsx
+++ b/frontend/nocturne-web/src/ui/Divider.tsx
@@ -1,0 +1,17 @@
+interface DividerProps {
+  label?: string;
+  className?: string;
+}
+
+export function Divider({ label, className = '' }: DividerProps) {
+  if (label) {
+    return (
+      <div className={`flex items-center gap-3 ${className}`}>
+        <div className="flex-1 h-px bg-border" />
+        <span className="text-[10px] uppercase tracking-widest text-muted">{label}</span>
+        <div className="flex-1 h-px bg-border" />
+      </div>
+    );
+  }
+  return <div className={`h-px bg-border ${className}`} />;
+}

--- a/frontend/nocturne-web/src/ui/Input.tsx
+++ b/frontend/nocturne-web/src/ui/Input.tsx
@@ -1,0 +1,26 @@
+import type { InputHTMLAttributes } from 'react';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
+
+export function Input({ label, className = '', id, ...props }: InputProps) {
+  const inputId = id ?? (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="text-[10px] uppercase tracking-widest text-muted"
+        >
+          {label}
+        </label>
+      )}
+      <input
+        id={inputId}
+        {...props}
+        className={`bg-transparent border-0 border-b border-border focus:border-text outline-none text-text placeholder:text-muted text-[14px] py-2 transition-colors ${className}`}
+      />
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/ui/Spinner.tsx
+++ b/frontend/nocturne-web/src/ui/Spinner.tsx
@@ -1,0 +1,26 @@
+interface SpinnerProps {
+  size?: number;
+  className?: string;
+}
+
+export function Spinner({ size = 14, className = '' }: SpinnerProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`animate-spin ${className}`}
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeOpacity="0.2" strokeWidth="2" />
+      <path
+        d="M21 12a9 9 0 0 0-9-9"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/nocturne-web/src/ui/index.ts
+++ b/frontend/nocturne-web/src/ui/index.ts
@@ -1,0 +1,7 @@
+export { Button } from './Button';
+export { Card } from './Card';
+export { Chip } from './Chip';
+export { Input } from './Input';
+export { Dialog } from './Dialog';
+export { Divider } from './Divider';
+export { Spinner } from './Spinner';

--- a/frontend/nocturne-web/src/views/LibraryView.tsx
+++ b/frontend/nocturne-web/src/views/LibraryView.tsx
@@ -1,0 +1,148 @@
+import type { ReactNode } from 'react';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Spinner } from '../ui/Spinner';
+import { MoodChips } from '../components/MoodChips';
+import { MovieGrid } from '../components/MovieGrid';
+import type { ViewMode } from '../components/MovieGrid';
+import type { MoodBuckets, Movie } from '../lib/types';
+
+interface LibraryViewProps {
+  movies: Movie[];
+  moods: MoodBuckets;
+  moodCounts: Record<string, number>;
+  stats: { total: number; tagged: number; untagged: number };
+  viewMode: ViewMode;
+  onViewModeChange: (v: ViewMode) => void;
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+  selectedMood: string;
+  onMoodChange: (slug: string) => void;
+  loading: boolean;
+  onSync: () => void;
+  onEditMovie: (movie: Movie) => void;
+  // Render slots (stay in App.tsx for now; extracted later)
+  backfillBanner?: ReactNode;
+  pendingSuggestionsPanel?: ReactNode;
+}
+
+export function LibraryView({
+  movies,
+  moods,
+  moodCounts,
+  stats,
+  viewMode,
+  onViewModeChange,
+  searchQuery,
+  onSearchChange,
+  selectedMood,
+  onMoodChange,
+  loading,
+  onSync,
+  onEditMovie,
+  backfillBanner,
+  pendingSuggestionsPanel,
+}: LibraryViewProps) {
+  return (
+    <>
+      <header className="border-b border-border bg-bg sticky top-14 lg:top-0 z-20">
+        <div className="px-5 lg:px-10 py-6 lg:py-8 flex flex-col gap-6">
+          {/* Title row */}
+          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+            <div>
+              <h1 className="font-serif italic text-3xl lg:text-4xl text-text">Library</h1>
+              <p className="text-[11px] uppercase tracking-widest text-muted mt-2">
+                {movies.length.toLocaleString()} shown · {stats.tagged} tagged · {stats.untagged} untagged
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <ViewModeToggle value={viewMode} onChange={onViewModeChange} />
+              <Button variant="line" onClick={onSync} disabled={loading}>
+                {loading ? 'Syncing…' : 'Sync library'}
+              </Button>
+            </div>
+          </div>
+
+          {/* Search */}
+          <div className="max-w-md">
+            <Input
+              placeholder="Search films…"
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+            />
+          </div>
+
+          {/* Mood chips */}
+          <MoodChips
+            moods={moods}
+            counts={moodCounts}
+            selected={selectedMood}
+            onSelect={onMoodChange}
+          />
+        </div>
+      </header>
+
+      {backfillBanner}
+      {pendingSuggestionsPanel}
+
+      <main className="px-5 lg:px-10 py-8">
+        {movies.length === 0 && !loading ? (
+          <EmptyState />
+        ) : (
+          <MovieGrid movies={movies} viewMode={viewMode} onEditMovie={onEditMovie} />
+        )}
+      </main>
+    </>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <Spinner size={28} className="text-muted" />
+      <p className="mt-5 font-serif italic text-2xl text-text">No films match.</p>
+      <p className="mt-1 text-[13px] text-text-dim">Clear the search or pick a different mood.</p>
+    </div>
+  );
+}
+
+interface ViewModeToggleProps {
+  value: ViewMode;
+  onChange: (v: ViewMode) => void;
+}
+
+function ViewModeToggle({ value, onChange }: ViewModeToggleProps) {
+  return (
+    <div className="inline-flex border border-border" role="group" aria-label="View mode">
+      <button
+        type="button"
+        onClick={() => onChange('tile')}
+        aria-pressed={value === 'tile'}
+        aria-label="Grid view"
+        className={`p-2 transition-colors cursor-pointer ${
+          value === 'tile' ? 'bg-text text-bg' : 'bg-bg text-muted hover:text-text'
+        }`}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+          <rect x="3" y="3" width="7" height="7" />
+          <rect x="14" y="3" width="7" height="7" />
+          <rect x="3" y="14" width="7" height="7" />
+          <rect x="14" y="14" width="7" height="7" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('list')}
+        aria-pressed={value === 'list'}
+        aria-label="List view"
+        className={`p-2 transition-colors cursor-pointer border-l border-border ${
+          value === 'list' ? 'bg-text text-bg' : 'bg-bg text-muted hover:text-text'
+        }`}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+          <path d="M3 6h18M3 12h18M3 18h18" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/views/SettingsView.tsx
+++ b/frontend/nocturne-web/src/views/SettingsView.tsx
@@ -1,0 +1,295 @@
+import { useRef } from 'react';
+import { Button } from '../ui/Button';
+import { Dialog } from '../ui/Dialog';
+import { Divider } from '../ui/Divider';
+import { JellyfinConnectForm } from '../components/JellyfinConnectForm';
+import { ApiKeyForm } from '../components/ApiKeyForm';
+import type { BackfillStatusApi } from '../lib/types';
+
+interface SettingsViewProps {
+  open: boolean;
+  onClose: () => void;
+  // Data
+  movieCount: number;
+  untaggedCount: number;
+  reviewCount: number;
+  backfillStatus: BackfillStatusApi | null;
+  anthKeySet: boolean;
+  omdbKeySet: boolean;
+  autoTagEnabled: boolean;
+  syncing: boolean;
+  version?: string;
+  // Callbacks
+  onSync: () => void;
+  onStartBackfill: () => Promise<void>;
+  onCancelBackfill: () => Promise<void>;
+  onReprocessAll: () => Promise<void>;
+  onSaveAnthKey: (key: string) => Promise<void>;
+  onSaveOmdbKey: (key: string) => Promise<void>;
+  onToggleAutoTag: (next: boolean) => Promise<void>;
+  onClearMovies: () => Promise<void>;
+  onImportFile: (file: File) => Promise<void>;
+  onExportTags: () => Promise<void>;
+  onReviewUntaggedManually: () => void;
+}
+
+export function SettingsView(props: SettingsViewProps) {
+  const {
+    open,
+    onClose,
+    movieCount,
+    untaggedCount,
+    reviewCount,
+    backfillStatus,
+    anthKeySet,
+    omdbKeySet,
+    autoTagEnabled,
+    syncing,
+    version,
+    onSync,
+    onStartBackfill,
+    onCancelBackfill,
+    onReprocessAll,
+    onSaveAnthKey,
+    onSaveOmdbKey,
+    onToggleAutoTag,
+    onClearMovies,
+    onImportFile,
+    onExportTags,
+    onReviewUntaggedManually,
+  } = props;
+
+  const importRef = useRef<HTMLInputElement | null>(null);
+  const backfillRunning = backfillStatus?.running === true;
+  const backfillPct = backfillStatus && backfillStatus.total > 0
+    ? Math.min(100, Math.round((backfillStatus.processed / backfillStatus.total) * 100))
+    : 0;
+  const queueSize = untaggedCount + reviewCount;
+
+  return (
+    <Dialog open={open} onClose={onClose} title="Settings" size="lg">
+      <input
+        ref={importRef}
+        type="file"
+        accept="application/json"
+        hidden
+        onChange={async (e) => {
+          const file = e.target.files?.[0];
+          if (file) await onImportFile(file);
+          if (e.target) e.target.value = '';
+        }}
+      />
+
+      <div className="space-y-10">
+        {/* ACTIONS */}
+        <Section label="Actions">
+          <Row
+            title="Sync library"
+            help={`Pull the latest movies from Jellyfin.${movieCount > 0 ? ` ${movieCount} in local catalog.` : ''}`}
+            action={
+              <Button variant="primary" size="sm" onClick={onSync} disabled={syncing}>
+                {syncing ? 'Syncing…' : 'Sync now'}
+              </Button>
+            }
+          />
+          <Row
+            title="AI auto-tagger"
+            help={
+              !anthKeySet
+                ? 'Requires an Anthropic API key.'
+                : backfillRunning
+                ? 'Running in background.'
+                : `${untaggedCount} untagged · ${reviewCount} in review`
+            }
+            action={
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={onStartBackfill}
+                disabled={!anthKeySet || backfillRunning || queueSize === 0}
+              >
+                {backfillRunning ? 'Running…' : 'Start auto-tag'}
+              </Button>
+            }
+          >
+            {backfillRunning && (
+              <div className="mt-3 space-y-2">
+                <div className="h-[2px] bg-border overflow-hidden">
+                  <div className="h-full bg-text transition-all" style={{ width: `${backfillPct}%` }} />
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[10px] uppercase tracking-widest text-muted">
+                    {backfillStatus?.processed ?? 0} / {backfillStatus?.total ?? 0}
+                    {backfillStatus?.cancelled && <span className="ml-2">· cancelling</span>}
+                  </span>
+                  {!backfillStatus?.cancelled && (
+                    <button
+                      onClick={onCancelBackfill}
+                      className="text-[10px] uppercase tracking-widest text-text-dim hover:text-text underline decoration-dotted underline-offset-2 cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="mt-3">
+              <button
+                onClick={onReviewUntaggedManually}
+                className="text-[11px] text-muted hover:text-text underline decoration-dotted underline-offset-2 cursor-pointer"
+              >
+                Review untagged manually →
+              </button>
+            </div>
+          </Row>
+          <Row
+            title="Reprocess all tagged films"
+            help="Clear every movie's tags and re-run the tagger against the whole library. Uses the Anthropic API per movie."
+            action={
+              <Button
+                variant="line"
+                size="sm"
+                onClick={async () => {
+                  if (!confirm(`Clear tags on all ${movieCount} films and re-tag them with Claude?`)) return;
+                  await onReprocessAll();
+                }}
+                disabled={!anthKeySet || backfillRunning || movieCount === 0}
+              >
+                Reprocess all
+              </Button>
+            }
+          />
+        </Section>
+
+        {/* CONFIGURATION */}
+        <Section label="Configuration">
+          <div className="border border-border p-5">
+            <div className="text-[11px] uppercase tracking-widest text-muted mb-4">Jellyfin</div>
+            <JellyfinConnectForm loadExisting />
+          </div>
+
+          <div className="border border-border p-5 space-y-5">
+            <div className="text-[11px] uppercase tracking-widest text-muted">API keys</div>
+            <ApiKeyForm
+              label="Anthropic API key"
+              placeholder="sk-ant-…"
+              helpText="Required for AI auto-tagging."
+              isSet={anthKeySet}
+              onSave={onSaveAnthKey}
+            />
+            <Divider />
+            <ApiKeyForm
+              label="OMDb API key"
+              placeholder="omdb api key"
+              helpText="Optional: IMDb, Rotten Tomatoes & Metacritic scores."
+              isSet={omdbKeySet}
+              onSave={onSaveOmdbKey}
+            />
+          </div>
+
+          <Row
+            title="Auto-tag on sync"
+            help={
+              !anthKeySet
+                ? 'Requires an Anthropic API key.'
+                : 'New films from sync get tagged automatically. Low-confidence suggestions go to review.'
+            }
+            action={
+              <Toggle
+                active={autoTagEnabled}
+                disabled={!anthKeySet}
+                onChange={(next) => onToggleAutoTag(next)}
+              />
+            }
+          />
+        </Section>
+
+        {/* DATA */}
+        <Section label="Data & maintenance">
+          <div className="border border-border p-5 flex flex-wrap items-center gap-2">
+            <Button variant="line" size="sm" onClick={() => importRef.current?.click()}>
+              Import tags (JSON)
+            </Button>
+            <Button variant="line" size="sm" onClick={onExportTags}>
+              Export tags (JSON)
+            </Button>
+          </div>
+          <div className="border border-border p-5">
+            <div className="text-[11px] uppercase tracking-widest text-muted mb-3">Danger zone</div>
+            <Button
+              variant="line"
+              size="sm"
+              onClick={async () => {
+                if (!confirm('Delete all films from Nocturne (not Jellyfin) and reset tag usage counts?')) return;
+                await onClearMovies();
+              }}
+            >
+              Clear local films
+            </Button>
+            <p className="mt-2 text-[11px] text-muted">Deletes the local catalog and resets usage. Jellyfin untouched.</p>
+          </div>
+        </Section>
+
+        {version && (
+          <div className="text-center text-[10px] uppercase tracking-widest text-muted pt-2 border-t border-border">
+            {version}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <div className="text-[10px] uppercase tracking-widest text-muted mb-3">{label}</div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function Row({
+  title,
+  help,
+  action,
+  children,
+}: {
+  title: string;
+  help: string;
+  action: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="text-[14px] text-text">{title}</div>
+          <p className="text-[12px] text-text-dim mt-1 leading-snug">{help}</p>
+        </div>
+        <div className="flex-shrink-0">{action}</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Toggle({ active, disabled, onChange }: { active: boolean; disabled?: boolean; onChange: (next: boolean) => void }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={active}
+      disabled={disabled}
+      onClick={() => onChange(!active)}
+      className={`inline-flex h-5 w-9 items-center border transition-colors cursor-pointer ${
+        active ? 'bg-text border-text' : 'bg-bg border-border'
+      } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+    >
+      <span
+        className={`inline-block h-3 w-3 bg-bg transition-transform ${
+          active ? 'translate-x-[18px]' : 'translate-x-[3px]'
+        } ${active ? 'bg-bg' : 'bg-muted'}`}
+      />
+    </button>
+  );
+}

--- a/frontend/nocturne-web/src/views/onboarding/ConnectStep.tsx
+++ b/frontend/nocturne-web/src/views/onboarding/ConnectStep.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+import { Button } from '../../ui/Button';
+import { Input } from '../../ui/Input';
+import { Divider } from '../../ui/Divider';
+import { Spinner } from '../../ui/Spinner';
+import type { DiscoveredServer } from '../../lib/types';
+
+interface ConnectStepProps {
+  onConnected: () => void;
+}
+
+export function ConnectStep({ onConnected }: ConnectStepProps) {
+  const [discovering, setDiscovering] = useState(false);
+  const [servers, setServers] = useState<DiscoveredServer[]>([]);
+  const [url, setUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runDiscovery() {
+    setDiscovering(true);
+    setError(null);
+    try {
+      const { servers: found } = await api.jellyfin.discover();
+      setServers(found);
+    } catch {
+      // Non-fatal — manual URL is always available.
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  useEffect(() => {
+    runDiscovery();
+  }, []);
+
+  function pickServer(s: DiscoveredServer) {
+    setUrl(s.address);
+  }
+
+  async function connect() {
+    if (!url || !username) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await api.settings.saveJellyfin(url.trim(), username.trim(), password);
+      if (r.success) {
+        // Kick off an initial sync so the local DB is populated before the user
+        // hits the library. DoneStep polls /sync/status and shows progress.
+        api.sync.trigger();
+        onConnected();
+      } else {
+        setError(r.error || 'Connection failed');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Connection failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-xl">
+      <p className="text-[10px] uppercase tracking-widest text-muted mb-3">Step 2 of 3 · Connect</p>
+      <h2 className="font-serif italic text-3xl lg:text-4xl text-text mb-2">Find your Jellyfin server</h2>
+      <p className="text-[13px] text-text-dim mb-8">
+        We broadcast on your local network and show any Jellyfin servers that respond.
+      </p>
+
+      {/* Discovered */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-[10px] uppercase tracking-widest text-muted">Discovered on your network</span>
+          <button
+            onClick={runDiscovery}
+            disabled={discovering}
+            className="text-[10px] uppercase tracking-widest text-muted hover:text-text cursor-pointer disabled:opacity-40"
+          >
+            {discovering ? 'Searching…' : 'Refresh'}
+          </button>
+        </div>
+        {discovering && servers.length === 0 && (
+          <div className="flex items-center gap-3 px-4 py-4 border border-border bg-surface text-[13px] text-text-dim">
+            <Spinner size={12} />
+            Searching…
+          </div>
+        )}
+        {!discovering && servers.length === 0 && (
+          <div className="px-4 py-4 border border-border text-[13px] text-text-dim">
+            No servers found. Enter your URL manually below.
+          </div>
+        )}
+        {servers.length > 0 && (
+          <div className="flex flex-col">
+            {servers.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => pickServer(s)}
+                className={`flex items-center justify-between px-4 py-4 border border-border hover:border-border-hover text-left cursor-pointer ${
+                  url === s.address ? 'bg-surface' : 'bg-bg'
+                } [&:not(:first-child)]:border-t-0`}
+              >
+                <div>
+                  <div className="text-[14px] text-text">{s.name}</div>
+                  <div className="text-[11px] text-muted mt-0.5">
+                    {s.address}
+                    {s.version && ` · Jellyfin ${s.version}`}
+                  </div>
+                </div>
+                <span className="text-[10px] uppercase tracking-widest text-muted">
+                  {url === s.address ? 'Selected' : 'Select →'}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Divider label="Or enter manually" />
+
+      <div className="mt-6 space-y-5">
+        <Input
+          label="Jellyfin URL"
+          placeholder="http://192.168.1.24:8096"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <Input
+          label="Username"
+          placeholder="admin"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <Input
+          label="Password"
+          type="password"
+          placeholder="••••••••"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+
+      {error && (
+        <div className="mt-5 border border-border bg-surface px-4 py-3 text-[13px] text-text">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-8 flex justify-end">
+        <Button variant="primary" onClick={connect} disabled={busy || !url || !username}>
+          {busy ? 'Connecting…' : 'Connect'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/views/onboarding/DoneStep.tsx
+++ b/frontend/nocturne-web/src/views/onboarding/DoneStep.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../../lib/api';
+import { Button } from '../../ui/Button';
+import { Spinner } from '../../ui/Spinner';
+import type { SyncStatus } from '../../lib/types';
+
+interface DoneStepProps {
+  onOpenLibrary: () => void;
+}
+
+export function DoneStep({ onOpenLibrary }: DoneStepProps) {
+  const [status, setStatus] = useState<SyncStatus | null>(null);
+  const [movieCount, setMovieCount] = useState<number | null>(null);
+  const pollRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const s = await api.sync.status();
+        if (cancelled) return;
+        setStatus(s);
+        if (!s.isRunning) {
+          const r = await api.movies.listAll(1, 0);
+          if (!cancelled) setMovieCount(r.totalCount);
+          return;
+        }
+      } catch {
+        // Transient; retry
+      }
+      pollRef.current = window.setTimeout(poll, 1000);
+    };
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (pollRef.current) window.clearTimeout(pollRef.current);
+    };
+  }, []);
+
+  const syncing = status?.isRunning !== false;
+
+  return (
+    <div className="flex flex-col items-center text-center max-w-xl">
+      <p className="text-[10px] uppercase tracking-widest text-muted mb-6">Step 3 of 3</p>
+      <h2 className="font-serif italic text-5xl text-text mb-3">
+        {syncing ? 'Syncing your library…' : "You're in."}
+      </h2>
+      {syncing ? (
+        <>
+          <div className="flex items-center gap-3 text-[14px] text-text-dim mb-10">
+            <Spinner size={14} />
+            {status && status.moviesFound > 0
+              ? `${status.moviesFound.toLocaleString()} films scanned`
+              : 'Scanning Jellyfin catalog'}
+          </div>
+          <Button variant="line" onClick={onOpenLibrary}>
+            Open library anyway
+          </Button>
+        </>
+      ) : (
+        <>
+          <p className="text-[14px] text-text-dim mb-2">
+            {movieCount !== null && <>{movieCount.toLocaleString()} films in your catalog</>}
+          </p>
+          <p className="text-[12px] text-muted max-w-md mb-10 leading-relaxed">
+            Add your Anthropic and OMDb keys from Settings when you're ready. Auto-tagging and
+            richer metadata unlock once they're set.
+          </p>
+          <Button variant="primary" onClick={onOpenLibrary}>
+            Open library
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/views/onboarding/OnboardingView.tsx
+++ b/frontend/nocturne-web/src/views/onboarding/OnboardingView.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { WelcomeStep } from './WelcomeStep';
+import { ConnectStep } from './ConnectStep';
+import { DoneStep } from './DoneStep';
+
+type Step = 'welcome' | 'connect' | 'done';
+
+interface OnboardingViewProps {
+  onFinished: () => void;
+}
+
+export function OnboardingView({ onFinished }: OnboardingViewProps) {
+  const [step, setStep] = useState<Step>('welcome');
+
+  return (
+    <div className="min-h-screen bg-bg text-text font-sans flex items-center justify-center px-5 py-10 relative">
+      <StepPips step={step} />
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.25 }}
+          className="flex justify-center"
+        >
+          {step === 'welcome' && <WelcomeStep onStart={() => setStep('connect')} />}
+          {step === 'connect' && <ConnectStep onConnected={() => setStep('done')} />}
+          {step === 'done' && <DoneStep onOpenLibrary={onFinished} />}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function StepPips({ step }: { step: Step }) {
+  const order: Step[] = ['welcome', 'connect', 'done'];
+  const active = order.indexOf(step);
+  return (
+    <div className="fixed top-8 left-1/2 -translate-x-1/2 flex gap-2">
+      {order.map((s, i) => (
+        <span
+          key={s}
+          className={`block w-6 h-px ${i === active ? 'bg-text' : 'bg-border'}`}
+          aria-current={i === active ? 'step' : undefined}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/nocturne-web/src/views/onboarding/WelcomeStep.tsx
+++ b/frontend/nocturne-web/src/views/onboarding/WelcomeStep.tsx
@@ -1,0 +1,17 @@
+import { Button } from '../../ui/Button';
+
+interface WelcomeStepProps {
+  onStart: () => void;
+}
+
+export function WelcomeStep({ onStart }: WelcomeStepProps) {
+  return (
+    <div className="flex flex-col items-center text-center max-w-xl">
+      <h1 className="font-serif italic text-6xl lg:text-7xl text-text mb-4">Nocturne</h1>
+      <p className="text-[14px] text-text-dim mb-10">Your library, indexed by mood.</p>
+      <Button variant="primary" onClick={onStart}>
+        Get started
+      </Button>
+    </div>
+  );
+}

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Nocturne</title>
-    <script type="module" crossorigin src="/assets/index-DRnhx5rr.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DbyVoHna.css">
+    <script type="module" crossorigin src="/assets/index-BAgUDs_T.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CJqYb82U.css">
   </head>
-  <body class="bg-white text-neutral-900">
+  <body class="bg-bg text-text">
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- **Componentize + restyle**: break the 1,875-line `App.tsx` monolith into a design system (`ui/`), composed components, and view containers. Replace ad-hoc styles (purple gradients, emerald buttons, mixed radii, frosted corners) with a single coherent palette — paper off-white, near-black text, zero color accents, square corners, EB Garamond italic serif display.
- **Jellyfin auto-discovery**: UDP broadcast on `:7359` → `POST /api/v1/jellyfin/discover`. Cross-platform POSIX sockets (macOS + Linux/Pi). Finds servers on the LAN automatically; manual URL stays as fallback.
- **Poster pipeline**: `GET /api/v1/movies/{id}/poster` proxies Jellyfin's primary-image API with an on-disk LRU cache (`data/cache/posters/`, 1 GiB cap). Tiles use it with text fallback.
- **Onboarding wizard**: 3-screen linear flow (Welcome → Connect with discovery → Done). Auto-triggers a sync on connect so imports and tag ops work from step 1 — no more "movie not found" on fresh installs.

## Architecture

```
frontend/nocturne-web/src/
├── App.tsx                 # 651 lines (was 1,875) — thin state owner
├── lib/                    # api.ts, types.ts
├── ui/                     # Button, Card, Chip, Input, Dialog, Divider, Spinner
├── components/             # Sidebar, MobileHeader, MoodChips, MovieTile,
│                           #   MovieListRow, MovieGrid, MovieDetailPanel,
│                           #   AutoTagQueue, BackfillProgress,
│                           #   JellyfinConnectForm, ApiKeyForm
└── views/                  # LibraryView, SettingsView, onboarding/*
```

Backend adds `JellyfinDiscovery.swift`, `PosterCache.swift`, and config fields (`posterCacheDir`, `posterCacheMaxBytes`, `jellyfinDiscoveryTimeoutMs`). Dockerfile pre-creates `/app/data/cache/posters`.

## Design tokens (Tailwind v4 `@theme`)
- `--color-bg: #fafaf9` / `--color-surface: #f5f5f4` / `--color-text: #0c0a09`
- `--font-serif: "EB Garamond"` (self-hosted via `@fontsource`, no CDN)
- `--radius-DEFAULT: 0px` — square corners system-wide
- `--tracking-wider: 0.12em` / `--tracking-widest: 0.18em` for uppercase labels

## Test plan
- [x] `swift build` clean
- [x] `npm run build` clean; `tsc --noEmit` clean
- [x] Fresh DB → onboarding wizard renders; Connect auto-discovered "PoGo" at `192.168.0.190:1009` via UDP
- [x] Library tiles fetch posters through `/api/v1/movies/{id}/poster` (disk-cached on 2nd hit)
- [x] Edit dialog / AutoTagQueue / Settings all render in the new system
- [ ] Chrome DevTools iPhone viewport pass (sidebar → hamburger, grid 2 cols, dialog full-sheet)
- [ ] Reprocess the local Pi deployment: migrate, `docker compose up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)