### PR TITLE
style: pure white bg + neutral grey ramp

### DIFF
--- a/frontend/nocturne-web/src/index.css
+++ b/frontend/nocturne-web/src/index.css
@@ -1,14 +1,14 @@
 @import "tailwindcss";
 
 @theme {
-  /* Direction — Editorial Light (paper off-white, warm stone neutrals) */
-  --color-bg: #fafaf9;
-  --color-surface: #f5f5f4;
-  --color-border: #e7e5e4;
-  --color-border-hover: #d6d3d1;
-  --color-muted: #78716c;
-  --color-text: #0c0a09;
-  --color-text-dim: #44403c;
+  /* Direction — Editorial Light (pure white, neutral greys) */
+  --color-bg: #ffffff;
+  --color-surface: #fafafa;
+  --color-border: #e5e5e5;
+  --color-border-hover: #d4d4d4;
+  --color-muted: #737373;
+  --color-text: #0a0a0a;
+  --color-text-dim: #404040;
 
   --font-serif: "EB Garamond", Georgia, serif;
   --font-sans: system-ui, -apple-system, "Segoe UI", sans-serif;


### PR DESCRIPTION
Flip the off-white (`#fafaf9` stone-50) background to pure white with a neutral grey token ramp. Warmer stone greys clashed slightly against posters/chrome — neutral reads cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)