### PR TITLE
feat: collapsing library header with peek-on-scroll-up

### DIFF
--- a/frontend/nocturne-web/src/lib/useHeaderCollapsed.ts
+++ b/frontend/nocturne-web/src/lib/useHeaderCollapsed.ts
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Collapses a sticky header on "scroll down", expands on "scroll up".
+ *
+ * Uses direct input events (touch on mobile, wheel on desktop) — **not**
+ * the scroll event — because scroll events:
+ *   - fire continuously during momentum decay (the tail can flip direction)
+ *   - have sub-pixel jitter near momentum stop
+ *   - have no natural "end of one gesture" boundary the way touch does
+ *
+ * Mobile: `touchstart` captures the origin finger Y; `touchmove` compares
+ * against it to infer gesture direction; state can flip at most once per
+ * touch gesture (a single zig-zag of the finger cannot flap open-close).
+ * `touchend` / `touchcancel` resets for the next gesture.
+ *
+ * Desktop: `wheel` events accumulate into a burst that commits after 150ms
+ * of idle — again at most once per burst.
+ *
+ * No scroll listener at all, so momentum / rubber-band / iOS bounce can't
+ * affect the state.
+ */
+export function useHeaderCollapsed(threshold = 80, flipDelta = 50): boolean {
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    // ---- Mobile: touch-based ------------------------------------------
+    let touchStartY: number | null = null;
+    let flippedThisTouch = false;
+
+    const onTouchStart = (e: TouchEvent) => {
+      const t = e.touches[0];
+      if (!t) return;
+      touchStartY = t.clientY;
+      flippedThisTouch = false;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (touchStartY === null || flippedThisTouch) return;
+      const t = e.touches[0];
+      if (!t) return;
+      // Finger moved up → user is scrolling the page down.
+      const fingerUp = touchStartY - t.clientY;
+      if (fingerUp > flipDelta && window.scrollY > threshold) {
+        setCollapsed(true);
+        flippedThisTouch = true;
+      } else if (fingerUp < -flipDelta) {
+        setCollapsed(false);
+        flippedThisTouch = true;
+      }
+    };
+
+    const onTouchEnd = () => {
+      touchStartY = null;
+      flippedThisTouch = false;
+    };
+
+    // ---- Desktop: wheel-based -----------------------------------------
+    let wheelAccum = 0;
+    let wheelTimer: number | null = null;
+    const onWheel = (e: WheelEvent) => {
+      wheelAccum += e.deltaY;
+      if (wheelTimer !== null) window.clearTimeout(wheelTimer);
+      wheelTimer = window.setTimeout(() => {
+        if (wheelAccum > flipDelta && window.scrollY > threshold) {
+          setCollapsed(true);
+        } else if (wheelAccum < -flipDelta) {
+          setCollapsed(false);
+        }
+        wheelAccum = 0;
+        wheelTimer = null;
+      }, 150);
+    };
+
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchmove', onTouchMove, { passive: true });
+    window.addEventListener('touchend', onTouchEnd, { passive: true });
+    window.addEventListener('touchcancel', onTouchEnd, { passive: true });
+    window.addEventListener('wheel', onWheel, { passive: true });
+
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+      window.removeEventListener('touchcancel', onTouchEnd);
+      window.removeEventListener('wheel', onWheel);
+      if (wheelTimer !== null) window.clearTimeout(wheelTimer);
+    };
+  }, [threshold, flipDelta]);
+
+  return collapsed;
+}

--- a/frontend/nocturne-web/src/views/LibraryView.tsx
+++ b/frontend/nocturne-web/src/views/LibraryView.tsx
@@ -6,6 +6,7 @@ import { MoodChips } from '../components/MoodChips';
 import { MovieGrid } from '../components/MovieGrid';
 import type { ViewMode } from '../components/MovieGrid';
 import type { MoodBuckets, Movie } from '../lib/types';
+import { useHeaderCollapsed } from '../lib/useHeaderCollapsed';
 
 interface LibraryViewProps {
   movies: Movie[];
@@ -43,36 +44,51 @@ export function LibraryView({
   backfillBanner,
   pendingSuggestionsPanel,
 }: LibraryViewProps) {
+  const collapsed = useHeaderCollapsed();
+
   return (
     <>
       <header className="border-b border-border bg-bg sticky top-14 lg:top-0 z-20">
-        <div className="px-5 lg:px-10 py-6 lg:py-8 flex flex-col gap-6">
-          {/* Title row */}
-          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-            <div>
-              <h1 className="font-serif italic text-3xl lg:text-4xl text-text">Library</h1>
-              <p className="text-[11px] uppercase tracking-widest text-muted mt-2">
-                {movies.length.toLocaleString()} shown · {stats.tagged} tagged · {stats.untagged} untagged
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <ViewModeToggle value={viewMode} onChange={onViewModeChange} />
-              <Button variant="line" onClick={onSync} disabled={loading}>
-                {loading ? 'Syncing…' : 'Sync library'}
-              </Button>
+        {/* Collapsible top: title + stats + actions + search.
+            `grid-rows-[1fr → 0fr]` gives a smooth height transition without
+            hard-coding a max-height. The inner div clips overflow so the
+            content doesn't bleed while animating. */}
+        <div
+          className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+            collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
+          }`}
+          aria-hidden={collapsed}
+        >
+          <div className="overflow-hidden min-h-0">
+            <div className="px-5 lg:px-10 pt-6 lg:pt-8 pb-5 flex flex-col gap-6">
+              <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+                <div>
+                  <h1 className="font-serif italic text-3xl lg:text-4xl text-text">Library</h1>
+                  <p className="text-[11px] uppercase tracking-widest text-muted mt-2">
+                    {movies.length.toLocaleString()} shown · {stats.tagged} tagged · {stats.untagged} untagged
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <ViewModeToggle value={viewMode} onChange={onViewModeChange} />
+                  <Button variant="line" onClick={onSync} disabled={loading}>
+                    {loading ? 'Syncing…' : 'Sync library'}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="max-w-md">
+                <Input
+                  placeholder="Search films…"
+                  value={searchQuery}
+                  onChange={(e) => onSearchChange(e.target.value)}
+                />
+              </div>
             </div>
           </div>
+        </div>
 
-          {/* Search */}
-          <div className="max-w-md">
-            <Input
-              placeholder="Search films…"
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-            />
-          </div>
-
-          {/* Mood chips */}
+        {/* Always-visible strip: mood chips */}
+        <div className="px-5 lg:px-10 py-3">
           <MoodChips
             moods={moods}
             counts={moodCounts}

--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Nocturne</title>
-    <script type="module" crossorigin src="/assets/index-BAgUDs_T.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CJqYb82U.css">
+    <script type="module" crossorigin src="/assets/index-DHyw6DVp.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BfTUJOgB.css">
   </head>
   <body class="bg-bg text-text">
     <div id="root"></div>


### PR DESCRIPTION
The library's sticky header now collapses its title/stats/search/actions row on scroll-down, leaving only the mood-chips strip pinned. Any scroll-up anywhere in the list re-expands it.

Detection uses direct input events (touchstart/touchmove on mobile, wheel on desktop) with a hard 'one flip per gesture' lock, instead of scroll events. Scroll events fire continuously during iOS momentum + rubber-band and cause the header to flap; touch events give a clean gesture boundary that no amount of zig-zag finger motion within a single touch can break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)